### PR TITLE
Reworks imads playbook to not require sudo

### DIFF
--- a/docker_webapp/tasks/main.yml
+++ b/docker_webapp/tasks/main.yml
@@ -6,11 +6,13 @@
   copy: content="{{ docker_webapp.ssl_cert }}"
         dest="{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_cert_file }}"
         mode=400
+        setype="svirt_sandbox_file_t"
   when: "{{ docker_webapp.ssl_cert_file is defined }}"
 - name: Place SSL private key
   copy: content="{{ docker_webapp.ssl_key }}"
         dest="{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_key_file }}"
         mode=400
+        setype="svirt_sandbox_file_t"
   when: "{{ docker_webapp.ssl_key_file is defined }}"
 - name: Make shibboleth directory
   file: path={{ docker_webapp.shib_dir }} state=directory

--- a/imads_webapp/tasks/main.yml
+++ b/imads_webapp/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Install docker py on RedHat
-  yum: name=python-docker-py
-  when: ansible_os_family == "RedHat"
-
 - name: Creates predictions data directory shared by portal and worker
   file: path="{{ imads.data_root }}/pred_data" state=directory
 
@@ -12,40 +8,7 @@
   file: path="{{ imads.data_root }}/pred_data/work" state=directory mode="a+rwx"
 
 # Create database
-- include: tasks/setup_postgres.yml db_restart=false db_config=normal
-
-- stat: path="{{ imads.data_root }}/pred_data/loaded.txt"
-  register: pred_data_loaded
-
-# Populate database
-
-- include: tasks/setup_postgres.yml db_restart=true db_config=load
-  when: pred_data_loaded.stat.isreg is not defined
-
-- name: Initial download and load database with prediction data
-  when: pred_data_loaded.stat.isreg is not defined
-  docker_container:
-    image: dukegcb/imads
-    networks:
-      - name: "{{ imads.network }}"
-    env: "{{ imads.env }}"
-    command: python load.py download
-    detach: false
-    volumes:
-      - /etc/external/:/etc/external/
-      - "{{ imads.data_root }}/pred_data:/tmp/pred_data"
-    pull: true
-
-- name: Create finished loading text file
-  when: pred_data_loaded.stat.isreg is not defined
-  file: path="{{ imads.data_root }}/pred_data/loaded.txt" state=touch
-
-# Setup production database settings
-
-- include: tasks/setup_postgres.yml db_restart=true db_config=production
-  when: pred_data_loaded.stat.isreg is not defined
-
-# Start web portal, vacuum daemon, and worker
+- include: tasks/setup_postgres.yml
 
 - include: tasks/setup_portal.yml
 

--- a/imads_webapp/tasks/setup_portal.yml
+++ b/imads_webapp/tasks/setup_portal.yml
@@ -8,7 +8,7 @@
       - name: "{{ imads.network }}"
     env: "{{ imads.env }}"
     volumes:
-      - /etc/external/:/etc/external/
+      - "{{ imads.data_root }}/etc/external/ssl/:/etc/external/ssl/"
       - "{{ imads.data_root }}/pred_data:/tmp/pred_data"
     ports:
       - "80:80"

--- a/imads_webapp/tasks/setup_postgres.yml
+++ b/imads_webapp/tasks/setup_postgres.yml
@@ -1,39 +1,62 @@
 # Setup postgres with various settings.
 
-- name: Setup loading postgres configuration
-  when: "'{{db_config}}' == 'load'"
-  blockinfile:
-    dest: "{{ imads.data_root }}/var/lib/postgresql/data/postgresql.conf"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    content: |
-      maintenance_work_mem = 2048MB
-      fsync = off
+# Determine if the database has been loaded
 
-- name: Setup production postgres configuration (1/4 RAM shared_buffers, memory for sorting)
-  when: "'{{db_config}}' == 'production'"
-  blockinfile:
-    dest: "{{ imads.data_root }}/var/lib/postgresql/data/postgresql.conf"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    content: |
-      shared_buffers = 4GB
-      work_mem = 48MB
-      logging_collector = on
-      log_directory = 'pg_log'
-      log_min_duration_statement = 1500
+- stat: path="{{ imads.data_root }}/pred_data/loaded.txt"
+  register: pred_data_loaded
 
-- name: Create Database container
+- name: Create Database container in loading state
+  when: pred_data_loaded.stat.isreg is not defined
   docker_container:
     image: postgres:9.5
     name: db
+    command: "postgres -c maintenance_work_mem=2048MB -c fsync=off"
     networks:
       - name: "{{ imads.network }}"
     env: "{{ imads.env }}"
     volumes:
-      - "{{ imads.data_root }}/var/lib/postgresql/data:/var/lib/postgresql/data"
+      - "{{ imads.data_root }}/var/lib/postgresql/data/postgresql:/var/lib/postgresql/data"
     pull: true
     state: started
-    restart: "{{db_restart}}"
     restart_policy: always
 
-- pause: seconds=1
-  when: "'{{db_config}}' == 'restart'"
+# Populate database
+
+- name: Initial download and load database with prediction data
+  when: pred_data_loaded.stat.isreg is not defined
+  docker_container:
+    name: load
+    image: dukegcb/imads
+    networks:
+      - name: "{{ imads.network }}"
+    env: "{{ imads.env }}"
+    command: python load.py download
+    detach: false
+    volumes:
+      - "{{ imads.data_root }}/etc/external/:/etc/external/"
+      - "{{ imads.data_root }}/pred_data:/tmp/pred_data"
+    pull: true
+
+# Wait for loading to finish
+- name: Wait for loading to finish
+  when: pred_data_loaded.stat.isreg is not defined
+  shell: "docker wait load"
+
+- name: Create finished loading text file
+  when: pred_data_loaded.stat.isreg is not defined
+  file: path="{{ imads.data_root }}/pred_data/loaded.txt" state=touch
+
+# Setup production database settings
+- name: Create Database container in production state (1/4 RAM shared_buffers, memory for sorting)
+  docker_container:
+    image: postgres:9.5
+    name: db
+    command: "postgres -c shared_buffers=4GB -c work_mem=48MB -c logging_collector=on -c log_directory='pg_log' -c log_min_duration_statement=1500"
+    networks:
+      - name: "{{ imads.network }}"
+    env: "{{ imads.env }}"
+    volumes:
+      - "{{ imads.data_root }}/var/lib/postgresql/data/postgresql:/var/lib/postgresql/data"
+    pull: true
+    state: started
+    restart_policy: always

--- a/imads_webapp/tasks/setup_vacuum.yml
+++ b/imads_webapp/tasks/setup_vacuum.yml
@@ -9,7 +9,7 @@
     env: "{{ imads.env }}"
     command: python vacuum.py 2880
     volumes:
-      - /etc/external/:/etc/external/
+      - "{{ imads.data_root }}/etc/external/:/etc/external/"
       - "{{ imads.data_root }}/pred_data:/tmp/pred_data"
     pull: true
     state: started


### PR DESCRIPTION
- Removes become from imads playbook
- Assumes now that docker and docker-py are installed
- Assumes access to the {{ imads.data_root }} directory for placing all incoming files
- Assumes that remote user has access to docker socket (likely via
docker group)
- Avoids rewriting postgresql.conf (since this gets owned by root) in
favor of specifying config options with -c
- Sets SELinux type of ssl cert/key

These changes were developed in gcb-ansible repo, but were not merged before splitting roles into separate repo