### PR TITLE
Remove quay from bespin images

### DIFF
--- a/bespin_job_watcher/tasks/main.yml
+++ b/bespin_job_watcher/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Create bespin-job-watcher container
   docker_container:
-    image: quay.io/dukegcb/bespin-job-watcher
+    image: dukegcb/bespin-job-watcher
     name: bespin-job-watcher
     volumes:
       - /etc/external/:/etc/external/

--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Create app container
   docker_container:
-    image: quay.io/dukegcb/bespin-lando
+    image: dukegcb/bespin-lando
     name: bespin-lando
     volumes:
       - /etc/external/:/etc/external/

--- a/bespin_web/tasks/main.yml
+++ b/bespin_web/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Create app container
   docker_container:
-    image: quay.io/dukegcb/bespin-web
+    image: dukegcb/bespin-web
     name: bespin-web
     env: "{{ web_environment }}"
     volumes:


### PR DESCRIPTION
We are moving the images from quay to docker due to ease of automating container rebuilds from multiple github repositories.