### PR TITLE
Update bespin_job_watcher role to use rabbit host from variable

### DIFF
--- a/bespin_job_watcher/templates/config.j2
+++ b/bespin_job_watcher/templates/config.j2
@@ -10,7 +10,7 @@
     "exchange": "job_status",
     "user": "{{ bespin_settings.rabbit.username }}",
     "password": "{{ bespin_settings.rabbit.password }}",
-    "host": "bespin-rabbit",
+    "host": "{{ bespin_settings.rabbit.host }}",
     "port": 5672
   },
   "bespinapi": {


### PR DESCRIPTION
Previously host was hardcoded to `bespin-rabbit`