### PR TITLE
Allow jupyterhub runtime/mem to be specified as variables

### DIFF
--- a/jupyterhub/defaults/main.yml
+++ b/jupyterhub/defaults/main.yml
@@ -4,3 +4,5 @@ authenticator: "pam"
 docker_image: "jupyterhub/singleuser"
 slurm_partition: "all"
 slurm_account: ""
+req_runtime: 120
+req_memory: 4096

--- a/jupyterhub/tasks/main.yml
+++ b/jupyterhub/tasks/main.yml
@@ -268,8 +268,8 @@
     marker: "# {mark} ANSIBLE MANAGED SLURM CONFIG"
     block: |
       c.SlurmSpawner.req_partition = '{{ slurm_partition }}'
-      c.BatchSpawnerBase.req_runtime = '60'
-      c.BatchSpawnerBase.req_memory = '4096'
+      c.BatchSpawnerBase.req_runtime = '{{ req_runtime }}'
+      c.BatchSpawnerBase.req_memory = '{{ req_memory }}'
       c.BatchSpawnerBase.env_keep = ['LANG','JUPYTERHUB_API_TOKEN','JPY_API_TOKEN']
       c.SlurmSpawner.batch_script = """#!/bin/bash
       #SBATCH --partition={partition}


### PR DESCRIPTION
RT Ticket requests increasing the runtime allotted to the jupyterhub job. This allows us to adjust the runtime in a variable (default provided).