### PR TITLE
Specify jupyterhub version to be installed

### DIFF
--- a/jupyterhub/defaults/main.yml
+++ b/jupyterhub/defaults/main.yml
@@ -6,3 +6,4 @@ slurm_partition: "all"
 slurm_account: ""
 req_runtime: 120
 req_memory: 4096
+jupyterhub_version: "0.8.0"

--- a/jupyterhub/defaults/main.yml
+++ b/jupyterhub/defaults/main.yml
@@ -7,3 +7,4 @@ slurm_account: ""
 req_runtime: 120
 req_memory: 4096
 jupyterhub_version: "0.8.0"
+jupyter_version: "1.0.0"

--- a/jupyterhub/tasks/main.yml
+++ b/jupyterhub/tasks/main.yml
@@ -123,7 +123,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install Jupyter via pip
-  pip: executable="{{ pip_executable }}" name=jupyter extra_args='--upgrade'
+  pip: executable="{{ pip_executable }}" name=jupyter version="{{ jupyter_version }}" extra_args='--upgrade'
   tags: jupyter-deps
 
 - name: install jupyterhub via pip

--- a/jupyterhub/tasks/main.yml
+++ b/jupyterhub/tasks/main.yml
@@ -122,13 +122,13 @@
     pip_executable: "/usr/bin/pip3"
   when: ansible_os_family == 'Debian'
 
-
-- name: install jupyter, jupyterhub via pip
-  pip: executable="{{ pip_executable }}" name={{item}} extra_args='--upgrade'
+- name: Install Jupyter via pip
+  pip: executable="{{ pip_executable }}" name=jupyter extra_args='--upgrade'
   tags: jupyter-deps
-  with_items:
-  - jupyter
-  - jupyterhub
+
+- name: install jupyterhub via pip
+  pip: executable="{{ pip_executable }}" name=jupyterhub version="{{ jupyterhub_version }}" extra_args='--upgrade'
+  tags: jupyter-deps
 
 - name: install sudospawner via pip
   pip: executable={{pip_executable}} name=sudospawner


### PR DESCRIPTION
On last installation, JupyterHub 0.8.1 failed to start. Previous role would always upgrade, which is dangerous for these reasons. So now, jupyterhub version is specified (0.8.0) and will be kept.