### PR TITLE
Bespin job vmsettings

### DIFF
--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Create app container
   docker_container:
-    image: dukegcb/bespin-lando
+    image: dukegcb/bespin-lando:92-per-job-vm-details
     name: bespin-lando
     volumes:
       - /etc/lando_config.yml:/etc/lando_config.yml

--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Create app container
   docker_container:
-    image: dukegcb/bespin-lando
+    image: "dukegcb/bespin-lando:{{ bespin_settings.lando.version }}"
     name: bespin-lando
     volumes:
       - /etc/lando_config.yml:/etc/lando_config.yml

--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Create app container
   docker_container:
-    image: dukegcb/bespin-lando:92-per-job-vm-details
+    image: dukegcb/bespin-lando
     name: bespin-lando
     volumes:
       - /etc/lando_config.yml:/etc/lando_config.yml

--- a/bespin_lando/templates/lando_config.yml.j2
+++ b/bespin_lando/templates/lando_config.yml.j2
@@ -5,25 +5,6 @@ work_queue:
   listen_queue: "{{ bespin_settings.rabbit.listen_queue }}"
   worker_username: "{{ bespin_settings.rabbit.worker_username }}"
   worker_password: "{{ bespin_settings.rabbit.worker_password }}"
-vm_settings:
-  worker_image_name: "{{ bespin_settings.worker_vm.image_name }}"
-  ssh_key_name: "{{ bespin_settings.worker_vm.ssh_key_name }}"
-  network_name: "{{ bespin_settings.worker_vm.network_name }}"
-  floating_ip_pool_name: "{{ bespin_settings.worker_vm.floating_ip_pool_name }}"
-  default_flavor_name: "{{ bespin_settings.worker_vm.default_flavor_name }}"
-  cwl_base_command:
-  {% for item in bespin_settings.worker_vm.cwl_base_command -%}
-  {{ '  ' }}- "{{ item }}"
-  {% endfor -%}
-  cwl_post_process_command:
-  {% for item in bespin_settings.worker_vm.cwl_post_process_command -%}
-  {{ '  ' }}- "{{ item }}"
-  {% endfor -%}
-  volume_mounts:
-  {% for device, mount in  bespin_settings.worker_vm.volume_mounts.iteritems() -%}
-  {{ '  ' }}{{ device }}: {{ mount }}
-  {% endfor %}
-
 cloud_settings:
   auth_url: "{{ bespin_settings.worker_openstack.auth_url }}"
   username: "{{ bespin_settings.worker_openstack.username }}"

--- a/bespin_lando/templates/lando_config.yml.j2
+++ b/bespin_lando/templates/lando_config.yml.j2
@@ -6,11 +6,11 @@ work_queue:
   worker_username: "{{ bespin_settings.rabbit.worker_username }}"
   worker_password: "{{ bespin_settings.rabbit.worker_password }}"
 cloud_settings:
-  auth_url: "{{ bespin_settings.worker_openstack.auth_url }}"
-  username: "{{ bespin_settings.worker_openstack.username }}"
-  password: "{{ bespin_settings.worker_openstack.password }}"
-  user_domain_name: "{{ bespin_settings.worker_openstack.user_domain_name }}"
-  project_domain_name: "{{ bespin_settings.worker_openstack.project_domain_name }}"
+  auth_url: "{{ bespin_settings.lando.auth_url }}"
+  username: "{{ bespin_settings.lando.username }}"
+  password: "{{ bespin_settings.lando.password }}"
+  user_domain_name: "{{ bespin_settings.lando.user_domain_name }}"
+  project_domain_name: "{{ bespin_settings.lando.project_domain_name }}"
 bespin_api:
   url: "{{ bespin_settings.web.url }}"
   token: "{{ bespin_settings.web.lando_token }}"


### PR DESCRIPTION
- Renames `bespin_settings.worker_openstack` -> `bespin_settings.lando` as these are settings for the lando config.
- Role to create lando docker container now expects tagged docker image version from `bespin_settings.lando.version`.
- Removes `vm_settings` from lando config template (details now provided in API)
