### PR TITLE
setup Bespin server's hosts file based on the inventory

### DIFF
--- a/copy_bespin_hosts/README.md
+++ b/copy_bespin_hosts/README.md
@@ -1,0 +1,30 @@
+# copy_bespin_hosts
+
+Ansible role that copies a list of Bespin hostname/IPs to /etc/hosts [bespin](https://github.com/Duke-GCB/bespin-api/)
+
+This role fills in the list of necessary hostname/IP entries for the components of Bespin.
+This role also creates an ansible fact to allow looking up IP from hostname in the form of a dictionary name `bespin_hosts_list`.
+
+
+## Usage
+
+This role requires the inventory to contain the necessary bespin component aliases and expects the
+ ansible fact named `bespin_env` to contain the name of the environment we are installing
+ bespin under (eg. 'dev' or 'prod')
+
+For example a dev inventory would look like so:
+```
+[bespin_dev]
+bespin_dev_rabbit ansible_host=<rabbit-ip-address>
+bespin_dev_web ansible_host= ansible_host=<web-ip-address>
+bespin_dev_lando ansible_host=<lando-ip-address>
+bespin_dev_database ansible_host=<database-ip-address>
+bespin_dev_nfs ansible_host=<nfs-ip-address>
+bespin_dev_job_watcher ansible_host=<job-watcher-ip-address>
+ ```
+
+You can specify the `bespin_env` fact for this group like so: 
+```
+[bespin_dev:vars]
+bespin_env=dev
+```

--- a/copy_bespin_hosts/tasks/main.yml
+++ b/copy_bespin_hosts/tasks/main.yml
@@ -1,12 +1,19 @@
-- copy:
-    src: /etc/hosts
-    dest: /etc/hosts
-    mode: 0644
+- name: Determine bespin hostnames based on environment (dev vs prod)
+  set_fact:
+    bespin_hosts: |
+      {{ hostvars['bespin_' + bespin_env + '_rabbit']['ansible_host'] }} bespin-{{ bespin_env }}-rabbit
+      {{ hostvars['bespin_' + bespin_env + '_web']['ansible_host'] }} bespin-{{ bespin_env }}-web
+      {{ hostvars['bespin_' + bespin_env + '_lando']['ansible_host'] }} bespin-{{ bespin_env }}-lando
+      {{ hostvars['bespin_' + bespin_env + '_database']['ansible_host'] }} bespin-{{ bespin_env }}-database
+      {{ hostvars['bespin_' + bespin_env + '_nfs']['ansible_host'] }} bespin-{{ bespin_env }}-nfs
+      {{ hostvars['bespin_' + bespin_env + '_job_watcher']['ansible_host'] }} bespin-{{ bespin_env }}-job-watcher
 
-- command: grep 'bespin-' /etc/hosts
-  register: bespin_hosts
+- name: Add bespin hosts to /etc/hosts
+  blockinfile:
+    path: /etc/hosts
+    block: "{{bespin_hosts}}"
 
 - name: Populate bespin_hosts_list
   set_fact:
     bespin_hosts_list: "{{ bespin_hosts_list|default({}) | combine( {item.split()[1]: item.split()[0]} ) }}"
-  with_items: "{{bespin_hosts.stdout_lines}}"
+  with_items: "{{bespin_hosts.splitlines()}}"


### PR DESCRIPTION
Changes copy_bespin_hosts to read the IP addresses from the inventory.
Previously we depended upon having a local /etc/hosts file.
This will allow bespin deployment from a central location.