### PR TITLE
Support around gitlab-runner and GitLab CI/CD of D4S2

### DIFF
--- a/d4s2_webapp/defaults/main.yml
+++ b/d4s2_webapp/defaults/main.yml
@@ -1,0 +1,1 @@
+d4s2_docker_image: dukegcb/d4s2-apache

--- a/d4s2_webapp/defaults/main.yml
+++ b/d4s2_webapp/defaults/main.yml
@@ -1,1 +1,0 @@
-d4s2_docker_image: dukegcb/d4s2-apache

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -31,3 +31,14 @@
     pull: true
     state: started
     restart_policy: always
+- name: Create task processor container
+  docker_container:
+    image: "{{ d4s2_docker_image }}"
+    name: worker
+    networks:
+      - name: "{{ d4s2_config_network }}"
+    env: "{{ d4s2_config_env }}"
+    pull: true
+    state: started
+    restart_policy: always
+    command: python manage.py process_tasks

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -3,8 +3,8 @@
     image: postgres:9.5
     name: db
     networks:
-      - name: "{{ d4s2_config.network }}"
-    env: "{{ d4s2_config.env }}"
+      - name: "{{ d4s2_docker_network }}"
+    env: "{{ d4s2_docker_env }}"
     volumes:
       - /var/lib/postgresql/data:/var/lib/postgresql/data
     pull: true
@@ -12,11 +12,11 @@
     restart_policy: always
 - name: Create app container
   docker_container:
-    image: dukegcb/d4s2-apache
+    image: "{{ d4s2_docker_image }}"
     name: web
     networks:
-      - name: "{{ d4s2_config.network }}"
-    env: "{{ d4s2_config.env }}"
+      - name: "{{ d4s2_docker_network }}"
+    env: "{{ d4s2_docker_env }}"
     volumes:
       - /etc/external/:/etc/external/
     ports:

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Login to docker registry
+  docker_login:
+    registry: "{{ docker_registry }}"
+    username: "{{ docker_username }}"
+    password: "{{ docker_password }}"
+  when: docker_registry is defined
 - name: Create Database container
   docker_container:
     image: postgres:9.5

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -36,8 +36,8 @@
     image: "{{ d4s2_docker_image }}"
     name: worker
     networks:
-      - name: "{{ d4s2_config_network }}"
-    env: "{{ d4s2_config_env }}"
+      - name: "{{ d4s2_docker_network }}"
+    env: "{{ d4s2_docker_env }}"
     pull: true
     state: started
     restart_policy: always

--- a/gitlab-runner/defaults/main.yml
+++ b/gitlab-runner/defaults/main.yml
@@ -1,0 +1,3 @@
+user_name: gitlab-runner
+ssh_key_source_path: ''
+ssh_key_dest_file_name: id_rsa

--- a/gitlab-runner/defaults/main.yml
+++ b/gitlab-runner/defaults/main.yml
@@ -1,3 +1,5 @@
 user_name: gitlab-runner
 ssh_key_source_path: ''
 ssh_key_dest_file_name: id_rsa
+git_crypt_key_source_path: ''
+git_crypt_key_dest_file_name: "git-crypt.key"

--- a/gitlab-runner/tasks/main.yml
+++ b/gitlab-runner/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Add gitlab-runner user to docker group
+  user:
+    name: gitlab-runner
+    groups: docker
+    append: yes

--- a/gitlab-runner/tasks/main.yml
+++ b/gitlab-runner/tasks/main.yml
@@ -1,5 +1,12 @@
 - name: Add gitlab-runner user to docker group
   user:
-    name: gitlab-runner
+    name: "{{ user_name }}"
     groups: docker
     append: yes
+- name: Make .ssh directory
+  file: path="/home/{{ user_name }}/.ssh" state=directory mode=0700
+- name: Place ssh private key for gitlab runner
+  copy:
+    src: "{{ ssh_key_source_path }}"
+    dest: "/home/{{ user_name }}/.ssh/{{ ssh_key_dest_file_name }}"
+    mode: 0400

--- a/gitlab-runner/tasks/main.yml
+++ b/gitlab-runner/tasks/main.yml
@@ -9,4 +9,6 @@
   copy:
     src: "{{ ssh_key_source_path }}"
     dest: "/home/{{ user_name }}/.ssh/{{ ssh_key_dest_file_name }}"
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
     mode: 0400

--- a/gitlab-runner/tasks/main.yml
+++ b/gitlab-runner/tasks/main.yml
@@ -12,3 +12,22 @@
     owner: "{{ user_name }}"
     group: "{{ user_name }}"
     mode: 0400
+- name: Install git-crypt and dependencies
+  apt:
+    name: "{{ item }}"
+    update_cache: yes
+  with_items:
+    - openssl
+    - git
+    - gnupg
+    - git-crypt
+- name: Import gpg public key from file in ansible repo
+  command: "gpg --import"
+  args:
+    stdin: "{{ lookup('file', gpg_public_key_local_path) }}"
+  become_user: "{{ user_name }}"
+- name: Import gpg private key from file in ansible repo
+  command: "gpg --import"
+  args:
+    stdin: "{{ lookup('file', gpg_private_key_local_path) }}"
+  become_user: "{{ user_name }}"

--- a/gitlab-runner/tasks/main.yml
+++ b/gitlab-runner/tasks/main.yml
@@ -19,15 +19,18 @@
   with_items:
     - openssl
     - git
-    - gnupg
     - git-crypt
-- name: Import gpg public key from file in ansible repo
-  command: "gpg --import"
-  args:
-    stdin: "{{ lookup('file', gpg_public_key_local_path) }}"
-  become_user: "{{ user_name }}"
-- name: Import gpg private key from file in ansible repo
-  command: "gpg --import"
-  args:
-    stdin: "{{ lookup('file', gpg_private_key_local_path) }}"
-  become_user: "{{ user_name }}"
+- name: Create .git-crypt directory for storing the symmetric key
+  file:
+    path: "/home/{{ user_name }}/.git-crypt/"
+    state: directory
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
+    mode: 0700
+- name: Place git-crypt symmetric key for decrypting the ansible repo
+  copy:
+    src: "{{ git_crypt_key_source_path }}"
+    dest: "/home/{{ user_name }}/.git-crypt/{{ git_crypt_key_dest_file_name }}"
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
+    mode: 0400

--- a/update_apt_cache/tasks/main.yml
+++ b/update_apt_cache/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Update apt cache
+  apt:
+    update_cache: yes


### PR DESCRIPTION
- Includes tasks to prep a host for GitLab Runner installation (but does not install gitlab-runner, there are galaxy roles to do that)
- Flattens some d4s2 variables for easier override
- Includes tasks to place ssh and git crypt keys on a gitlab runner host