### PR TITLE
Fix update_apt_cache to only run on debian

### DIFF
--- a/update_apt_cache/tasks/main.yml
+++ b/update_apt_cache/tasks/main.yml
@@ -1,3 +1,4 @@
 - name: Update apt cache
   apt:
     update_cache: yes
+  when: ansible_os_family == 'Debian'


### PR DESCRIPTION
Role would fail on yum systems