### PR TITLE
Update d4s2 webapp role to use nginx reverse proxy

### DIFF
--- a/d4s2_webapp/README.md
+++ b/d4s2_webapp/README.md
@@ -2,7 +2,12 @@
 
 Ansible role for deploying [D4S2](https://github.com/Duke-GCB/d4s2/)
 
-This role installs two named docker containers (web and db) to run the D4s2 application.
+This role installs 4 docker containersto run the datadelivery web application:
+
+- **db** - PostgreSQL database
+- **app** - D4S2 Django Web Application
+- **worker** - D4S2 Django Background Task processor
+- **web** - Nginx reverse proxy for https
 
 ## Dependencies
 
@@ -10,17 +15,21 @@ This role depends on the [docker_webapp](../docker_webapp) role.
 
 ## Usage
 
-This role reads the following variables out of a **d4s2_config** dictionary. Since some values are secret, this data should not be stored in plaintext.
+This role is designed to be used on hosts with docker installed, after the `docker_webapp` role.
+It reads host-specific and secret variables, which should be provided securely:
 
-    d4s2_config:
-      network: d4s2
-      env:
-        D4S2_SECRET_KEY: 'randomly-generated-key-here'
-        D4S2_DDSCLIENT_URL: 'https://dataservice.hostname/api/v1'
-        D4S2_DDSCLIENT_PORTAL_ROOT: 'https://dataservice.hostname'
-        D4S2_DDSCLIENT_AGENT_KEY: 'agent-key-here'
-        D4S2_SMTP_HOST: 'smtp-host'
-        D4S2_ROOT: 'https://deployment.hostname'
-        POSTGRES_USER: 'd4s2_user'
-        POSTGRES_PASSWORD: 'generated-posgres-password-here'
-        POSTGRES_DB: 'd4s2_db'
+    d4s2_docker_network: d4s2
+    d4s2_docker_env:
+      D4S2_ALLOWED_HOST: '*'
+      D4S2_SECRET_KEY: 'randomly-generated-key-here'
+      D4S2_DDSCLIENT_URL: 'https://dataservice.host.com/api/v1'
+      D4S2_DDSCLIENT_PORTAL_ROOT: 'https://dataservice.host.com'
+      D4S2_DDSCLIENT_OPENID_PROVIDER_ID: 'provider-id-from-dds-openid-provider'
+      D4S2_SMTP_HOST: 'smtp.host.com'
+      D4S2_DDSCLIENT_AGENT_KEY: 'agent-key-here'
+      D4S2_PRODUCTION: '1'
+      POSTGRES_USER: 'd4s2_user'
+      POSTGRES_PASSWORD: 'generated-postgres-password-here'
+      POSTGRES_DB: 'd4s2_db'
+      POSTGRES_HOST: 'db'
+

--- a/d4s2_webapp/README.md
+++ b/d4s2_webapp/README.md
@@ -2,7 +2,7 @@
 
 Ansible role for deploying [D4S2](https://github.com/Duke-GCB/d4s2/)
 
-This role installs 4 docker containersto run the datadelivery web application:
+This role installs 4 docker containers to run the datadelivery web application:
 
 - **db** - PostgreSQL database
 - **app** - D4S2 Django Web Application

--- a/d4s2_webapp/defaults/main.yml
+++ b/d4s2_webapp/defaults/main.yml
@@ -1,2 +1,3 @@
-d4s2_nginx_conf_dir: /etc/external/nginx
-d4s2_nginx_conf_file: nginx.conf
+d4s2_nginx:
+  conf_dir: /etc/external/nginx
+  conf_file: nginx.conf

--- a/d4s2_webapp/defaults/main.yml
+++ b/d4s2_webapp/defaults/main.yml
@@ -1,0 +1,2 @@
+d4s2_nginx_conf_dir: /etc/external/nginx
+d4s2_nginx_conf_file: nginx.conf

--- a/d4s2_webapp/files/nginx.conf
+++ b/d4s2_webapp/files/nginx.conf
@@ -1,0 +1,35 @@
+worker_processes  5;
+error_log  /dev/stdout info;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+  server {
+    listen 80;
+    return 301 https://$host$request_uri;
+  }
+
+  server {
+    listen    443;
+
+    ssl_certificate           /etc/nginx/cert.crt;
+    ssl_certificate_key       /etc/nginx/cert.key;
+
+    ssl on;
+    ssl_session_cache  builtin:1000  shared:SSL:10m;
+    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+      proxy_pass http://d4s2-app:8000;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+    }
+  }
+}

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Create app container
   docker_container:
     image: "{{ d4s2_docker_image }}"
-    name: api
+    name: d4s2-app
     networks:
       - name: "{{ d4s2_docker_network }}"
     env: "{{ d4s2_docker_env }}"
@@ -37,10 +37,10 @@
     state: started
     restart_policy: always
     command: python manage.py process_tasks
-- name: Create reverse proxy container
+- name: Create reverse proxy web container
   docker_container:
     image: nginx:1.13
-    name: revproxy
+    name: web
     networks:
       - name: "{{ d4s2_docker_network }}"
     volumes:

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -1,8 +1,8 @@
 - name: Make nginx directory
-  file: path={{ d4s2_nginx_conf_dir }} state=directory
+  file: path={{ d4s2_nginx.conf_dir }} state=directory
 - name: Place nginx conf
-  copy: src="{{ d4s2_nginx_conf_file }}"
-        dest="{{ d4s2_nginx_conf_dir }}/{{ d4s2_nginx_conf_file }}"
+  copy: src="{{ d4s2_nginx.conf_file }}"
+        dest="{{ d4s2_nginx.conf_dir }}/{{ d4s2_nginx.conf_file }}"
         mode=0400
         setype="svirt_sandbox_file_t"
 - name: Login to docker registry
@@ -51,7 +51,7 @@
     networks:
       - name: "{{ d4s2_docker_network }}"
     volumes:
-      - "{{ d4s2_nginx_conf_dir }}/{{ d4s2_nginx_conf_file }}:/etc/nginx/nginx.conf:ro"
+      - "{{ d4s2_nginx.conf_dir }}/{{ d4s2_nginx.conf_file }}:/etc/nginx/nginx.conf:ro"
       - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_cert_file }}:/etc/nginx/cert.crt:ro"
       - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_key_file }}:/etc/nginx/cert.key:ro"
     ports:

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -51,7 +51,7 @@
     networks:
       - name: "{{ d4s2_docker_network }}"
     volumes:
-      - "{{ docker_webapp.nginx_conf_dir }}/{{ docker_webapp.nginx_conf_file }}:/etc/nginx/nginx.conf:ro"
+      - "{{ d4s2_nginx_conf_dir }}/{{ d4s2_nginx_conf_file }}:/etc/nginx/nginx.conf:ro"
       - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_cert_file }}:/etc/nginx/cert.crt:ro"
       - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_key_file }}:/etc/nginx/cert.key:ro"
     ports:

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: Make nginx directory
+  file: path={{ d4s2_nginx_conf_dir }} state=directory
+- name: Place nginx conf
+  copy: src="{{ d4s2_nginx_conf_file }}"
+        dest="{{ d4s2_nginx_conf_dir }}/{{ d4s2_nginx_conf_file }}"
+        mode=0400
+        setype="svirt_sandbox_file_t"
 - name: Login to docker registry
   docker_login:
     registry: "{{ docker_registry }}"

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -44,7 +44,7 @@
     networks:
       - name: "{{ d4s2_docker_network }}"
     volumes:
-      - "{{ docker_webapp.nginx_conf_dir }}{{ docker_webapp.nginx_conf_file }}:/etc/nginx/nginx.conf:ro"
+      - "{{ docker_webapp.nginx_conf_dir }}/{{ docker_webapp.nginx_conf_file }}:/etc/nginx/nginx.conf:ro"
       - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_cert_file }}:/etc/nginx/cert.crt:ro"
       - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_key_file }}:/etc/nginx/cert.key:ro"
     ports:

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -19,15 +19,10 @@
 - name: Create app container
   docker_container:
     image: "{{ d4s2_docker_image }}"
-    name: web
+    name: api
     networks:
       - name: "{{ d4s2_docker_network }}"
     env: "{{ d4s2_docker_env }}"
-    volumes:
-      - /etc/external/:/etc/external/
-    ports:
-      - "80:80"
-      - "443:443"
     pull: true
     state: started
     restart_policy: always
@@ -42,3 +37,19 @@
     state: started
     restart_policy: always
     command: python manage.py process_tasks
+- name: Create reverse proxy container
+  docker_container:
+    image: nginx:1.13
+    name: revproxy
+    networks:
+      - name: "{{ d4s2_docker_network }}"
+    volumes:
+      - "{{ docker_webapp.nginx_conf_dir }}{{ docker_webapp.nginx_conf_file }}:/etc/nginx/nginx.conf:ro"
+      - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_cert_file }}:/etc/nginx/cert.crt:ro"
+      - "{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_key_file }}:/etc/nginx/cert.key:ro"
+    ports:
+      - "80:80"
+      - "443:443"
+    pull: true
+    state: started
+    restart_policy: always

--- a/docker_webapp/tasks/main.yml
+++ b/docker_webapp/tasks/main.yml
@@ -14,6 +14,14 @@
         mode=400
         setype="svirt_sandbox_file_t"
   when: "{{ docker_webapp.ssl_key_file is defined }}"
+- name: Make nginx directory
+  file: path={{ docker_webapp.nginx_conf_dir }} state=directory
+  when: "{{ docker_webapp.nginx_conf_dir is defined}}"
+- name: Place nginx conf
+  copy: content="{{ docker_webapp.nginx_conf }}"
+        dest="{{ docker_webapp.nginx_conf_dir }}/{{ docker_webapp.nginx_conf_file }}"
+        mode=0400
+        setype="svirt_sandbox_file_t"
 - name: Make shibboleth directory
   file: path={{ docker_webapp.shib_dir }} state=directory
   when: "{{ docker_webapp.shib_dir is defined}}"

--- a/docker_webapp/tasks/main.yml
+++ b/docker_webapp/tasks/main.yml
@@ -14,14 +14,6 @@
         mode=400
         setype="svirt_sandbox_file_t"
   when: docker_webapp.ssl_key_file is defined
-- name: Make nginx directory
-  file: path={{ docker_webapp.nginx_conf_dir }} state=directory
-  when: docker_webapp.nginx_conf_dir is defined
-- name: Place nginx conf
-  copy: content="{{ docker_webapp.nginx_conf }}"
-        dest="{{ docker_webapp.nginx_conf_dir }}/{{ docker_webapp.nginx_conf_file }}"
-        mode=0400
-        setype="svirt_sandbox_file_t"
 - name: Make shibboleth directory
   file: path={{ docker_webapp.shib_dir }} state=directory
   when: docker_webapp.shib_dir is defined

--- a/docker_webapp/tasks/main.yml
+++ b/docker_webapp/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: Make SSL directory
   file: path={{ docker_webapp.ssl_dir }} state=directory
-  when: "{{ docker_webapp.ssl_dir is defined}}"
+  when: docker_webapp.ssl_dir is defined
 - name: Place SSL certificate
   copy: content="{{ docker_webapp.ssl_cert }}"
         dest="{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_cert_file }}"
         mode=400
         setype="svirt_sandbox_file_t"
-  when: "{{ docker_webapp.ssl_cert_file is defined }}"
+  when: docker_webapp.ssl_cert_file is defined
 - name: Place SSL private key
   copy: content="{{ docker_webapp.ssl_key }}"
         dest="{{ docker_webapp.ssl_dir }}/{{ docker_webapp.ssl_key_file }}"
         mode=400
         setype="svirt_sandbox_file_t"
-  when: "{{ docker_webapp.ssl_key_file is defined }}"
+  when: docker_webapp.ssl_key_file is defined
 - name: Make nginx directory
   file: path={{ docker_webapp.nginx_conf_dir }} state=directory
-  when: "{{ docker_webapp.nginx_conf_dir is defined}}"
+  when: docker_webapp.nginx_conf_dir is defined
 - name: Place nginx conf
   copy: content="{{ docker_webapp.nginx_conf }}"
         dest="{{ docker_webapp.nginx_conf_dir }}/{{ docker_webapp.nginx_conf_file }}"
@@ -24,17 +24,17 @@
         setype="svirt_sandbox_file_t"
 - name: Make shibboleth directory
   file: path={{ docker_webapp.shib_dir }} state=directory
-  when: "{{ docker_webapp.shib_dir is defined}}"
+  when: docker_webapp.shib_dir is defined
 - name: Place Shibboleth SP certificate
   copy: content="{{ docker_webapp.shib_sp_cert }}"
         dest="{{ docker_webapp.shib_dir }}/{{ docker_webapp.shib_sp_cert_file }}"
         mode=400
-  when: "{{ docker_webapp.shib_sp_cert_file is defined }}"
+  when: docker_webapp.shib_sp_cert_file is defined
 - name: Place Shibboleth SP private key
   copy: content="{{ docker_webapp.shib_sp_key }}"
         dest="{{ docker_webapp.shib_dir }}/{{ docker_webapp.shib_sp_key_file }}"
         mode=400
-  when: "{{ docker_webapp.shib_sp_key_file is defined }}"
+  when: docker_webapp.shib_sp_key_file is defined
 - name: Check for network
   command: "docker network ls -q -f name=^{{ docker_webapp.network }}$"
   register: network_id


### PR DESCRIPTION
Adds an Nginx container to the role. 

Nginx is configured to handle https and proxy traffic to the app container. This simplifies the app container (no longer complicated by apache) and provides an easier path to serving the [Ember-based datadelivery-ui](https://github.com/Duke-GCB/datadelivery-ui)

Related to https://github.com/Duke-GCB/D4S2/pull/164