### PR TITLE
add bespin_lando_worker from gcb-ansible

### DIFF
--- a/bespin_lando_worker/README.md
+++ b/bespin_lando_worker/README.md
@@ -1,0 +1,27 @@
+# bespin_lando_worker
+
+Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) in worker configuration along with cwltool.
+
+This role installs the following:
+- **lando** - Code that will read messages related to staging data, running a specific workflow, and storing output
+- **cwltool** - Program to use for running the workflow
+
+This role sets up lando as a service and creates a nfs mount.
+Lando is installed directly from github repository.
+cwltool is installed via pypi release.
+
+## Dependencies
+None
+
+## Usage
+
+By default deploys latest lando and cwltool.
+Users can select a specific version in a playbook like so:
+```
+...
+  roles:
+    - role: bespin_lando_worker
+      lando_version: 0.9.3
+      cwltool_version: 1.0.20180912090223
+...
+```

--- a/bespin_lando_worker/README.md
+++ b/bespin_lando_worker/README.md
@@ -4,7 +4,7 @@ Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) in worker 
 
 This role installs the following:
 - **lando** - Code that will read messages related to staging data, running a specific workflow, and storing output
-- **cwltool** - Program to use for running the workflow
+- **cwltool** - Program to use for running the workflow, cwltool can be overridden if the tool is installable via pip3.
 
 This role sets up lando as a service and creates a nfs mount.
 Lando is installed directly from github repository.
@@ -22,6 +22,6 @@ Users can select a specific version in a playbook like so:
   roles:
     - role: bespin_lando_worker
       lando_version: 0.9.3
-      cwltool_version: 1.0.20180912090223
+      cwl_runner_version: 1.0.20180912090223
 ...
 ```

--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -1,5 +1,6 @@
 lando_version: master
-cwltool_version: latest
+cwl_runner: cwltool
+cwl_runner_version: latest
 lando_work_directory: /work
 path_to_lando_worker: /usr/local/bin/lando_worker
 worker_mount_name: /data

--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -1,7 +1,7 @@
-lando_worker:
+bespin_lando_worker:
   lando_version: 0.9.3
   cwltool_version: 1.0.20180912090223
   work_directory: /work
   path_to_lando_worker: /usr/local/bin/lando_worker
   mount_name: /data
-  mount_src: /mnt/bespin_datasets
+  mount_src: bespin-nfs:/mnt/bespin_datasets

--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -1,0 +1,7 @@
+lando_worker:
+  lando_version: 0.9.3
+  cwltool_version: 1.0.20180912090223
+  work_directory: /work
+  path_to_lando_worker: /usr/local/bin/lando_worker
+  mount_name: /data
+  mount_src: /mnt/bespin_datasets

--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -1,7 +1,6 @@
-bespin_lando_worker:
-  lando_version: 0.9.3
-  cwltool_version: 1.0.20180912090223
-  work_directory: /work
-  path_to_lando_worker: /usr/local/bin/lando_worker
-  mount_name: /data
-  mount_src: bespin-nfs:/mnt/bespin_datasets
+lando_version: master
+cwltool_version: latest
+lando_work_directory: /work
+path_to_lando_worker: /usr/local/bin/lando_worker
+worker_mount_name: /data
+worker_mount_src: bespin-nfs:/mnt/bespin_datasets

--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -2,6 +2,5 @@ lando_version: master
 cwl_runner: cwltool
 cwl_runner_version: latest
 lando_work_directory: /work
-path_to_lando_worker: /usr/local/bin/lando_worker
 worker_mount_name: /data
 worker_mount_src: bespin-nfs:/mnt/bespin_datasets

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -1,0 +1,61 @@
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install apt dependencies
+  apt:
+   name: "{{ packages }}"
+  vars:
+    packages:
+    - nfs-common
+    - libssl-dev
+
+- pip:
+    name: git+git://github.com/Duke-GCB/lando.git@{{ bespin_settings.lando.version }}
+    editable: false
+    executable: pip3
+
+- pip:
+    name: html5lib
+    executable: pip3
+
+- pip:
+    name: cwltool
+    version: {{ bespin_settings.lando.worker_cwltool_version }}
+    executable: pip3
+
+- file:
+    dest: /work
+    state: directory
+    owner: ubuntu
+    mode: 0744
+
+- name: Setup lando_worker service
+  blockinfile:
+    dest: /etc/systemd/system/lando_worker.service
+    create: yes
+    block: |
+      [Unit]
+      Description=Lando Service
+      After=multi-user.target
+      [Service]
+      Type=idle
+      ExecStart=/usr/local/bin/lando_worker
+      WorkingDirectory=/work
+      User=root
+      [Install]
+      WantedBy=multi-user.target
+
+- service:
+    name: lando_worker
+    state: started
+    enabled: yes
+
+- name: set mountpoints
+  mount:
+    name: /data
+    src: bespin-nfs:/mnt/bespin_datasets
+    fstype: nfs
+    opts: ro,sync,hard,intr
+    state: mounted
+

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -15,6 +15,11 @@
     editable: false
     executable: pip3
 
+- name: Check where lando_worker has been installed to
+  command: which lando_worker
+  register: which_lando_worker
+  changed_when: no
+
 - pip:
     name: html5lib
     executable: pip3
@@ -40,7 +45,7 @@
       After=multi-user.target
       [Service]
       Type=idle
-      ExecStart={{ path_to_lando_worker }}
+      ExecStart={{ which_lando_worker.stdout }}
       WorkingDirectory={{ lando_work_directory }}
       User=root
       [Install]

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -11,7 +11,7 @@
     - libssl-dev
 
 - pip:
-    name: git+git://github.com/Duke-GCB/lando.git@{{ bespin_worker.lando_version }}
+    name: "git+git://github.com/Duke-GCB/lando.git@{{ bespin_lando_worker.lando_version }}"
     editable: false
     executable: pip3
 
@@ -21,11 +21,11 @@
 
 - pip:
     name: cwltool
-    version: {{ bespin_worker.cwltool_version }}
+    version: "{{ bespin_lando_worker.cwltool_version }}"
     executable: pip3
 
 - file:
-    dest: {{ bespin_worker.work_directory }}
+    dest: "{{ bespin_lando_worker.work_directory }}"
     state: directory
     owner: ubuntu
     mode: 0744
@@ -40,8 +40,8 @@
       After=multi-user.target
       [Service]
       Type=idle
-      ExecStart={{ bespin_worker.path_to_lando_worker }}
-      WorkingDirectory={{ bespin_worker.work_directory }}
+      ExecStart={{ bespin_lando_worker.path_to_lando_worker }}
+      WorkingDirectory={{ bespin_lando_worker.work_directory }}
       User=root
       [Install]
       WantedBy=multi-user.target
@@ -53,8 +53,8 @@
 
 - name: set mountpoints
   mount:
-    name: {{ bespin_worker.mount_name }}
-    src: {{ bespin_worker.mount_src }}
+    name: "{{ bespin_lando_worker.mount_name }}"
+    src: "{{ bespin_lando_worker.mount_src }}"
     fstype: nfs
     opts: ro,sync,hard,intr
     state: mounted

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -20,8 +20,8 @@
     executable: pip3
 
 - pip:
-    name: cwltool
-    version: "{{ cwltool_version }}"
+    name: "{{ cwl_runner }}"
+    version: "{{ cwl_runner_version }}"
     executable: pip3
 
 - file:

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -11,7 +11,7 @@
     - libssl-dev
 
 - pip:
-    name: "git+git://github.com/Duke-GCB/lando.git@{{ bespin_lando_worker.lando_version }}"
+    name: "git+git://github.com/Duke-GCB/lando.git@{{ lando_version }}"
     editable: false
     executable: pip3
 
@@ -21,11 +21,11 @@
 
 - pip:
     name: cwltool
-    version: "{{ bespin_lando_worker.cwltool_version }}"
+    version: "{{ cwltool_version }}"
     executable: pip3
 
 - file:
-    dest: "{{ bespin_lando_worker.work_directory }}"
+    dest: "{{ lando_work_directory }}"
     state: directory
     owner: ubuntu
     mode: 0744
@@ -40,8 +40,8 @@
       After=multi-user.target
       [Service]
       Type=idle
-      ExecStart={{ bespin_lando_worker.path_to_lando_worker }}
-      WorkingDirectory={{ bespin_lando_worker.work_directory }}
+      ExecStart={{ path_to_lando_worker }}
+      WorkingDirectory={{ lando_work_directory }}
       User=root
       [Install]
       WantedBy=multi-user.target
@@ -53,8 +53,8 @@
 
 - name: set mountpoints
   mount:
-    name: "{{ bespin_lando_worker.mount_name }}"
-    src: "{{ bespin_lando_worker.mount_src }}"
+    name: "{{ worker_mount_name }}"
+    src: "{{ worker_mount_src }}"
     fstype: nfs
     opts: ro,sync,hard,intr
     state: mounted

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -11,7 +11,7 @@
     - libssl-dev
 
 - pip:
-    name: git+git://github.com/Duke-GCB/lando.git@{{ bespin_settings.lando.version }}
+    name: git+git://github.com/Duke-GCB/lando.git@{{ bespin_worker.lando_version }}
     editable: false
     executable: pip3
 
@@ -21,11 +21,11 @@
 
 - pip:
     name: cwltool
-    version: {{ bespin_settings.lando.worker_cwltool_version }}
+    version: {{ bespin_worker.cwltool_version }}
     executable: pip3
 
 - file:
-    dest: /work
+    dest: {{ bespin_worker.work_directory }}
     state: directory
     owner: ubuntu
     mode: 0744
@@ -40,8 +40,8 @@
       After=multi-user.target
       [Service]
       Type=idle
-      ExecStart=/usr/local/bin/lando_worker
-      WorkingDirectory=/work
+      ExecStart={{ bespin_worker.path_to_lando_worker }}
+      WorkingDirectory={{ bespin_worker.work_directory }}
       User=root
       [Install]
       WantedBy=multi-user.target
@@ -53,8 +53,8 @@
 
 - name: set mountpoints
   mount:
-    name: /data
-    src: bespin-nfs:/mnt/bespin_datasets
+    name: {{ bespin_worker.mount_name }}
+    src: {{ bespin_worker.mount_src }}
     fstype: nfs
     opts: ro,sync,hard,intr
     state: mounted


### PR DESCRIPTION
Copied this role from the [gcb-ansible](https://github.com/Duke-GCB/gcb-ansible) repo.
Includes modifications to be more flexible.
Variable `lando_version` specifies the version of lando to install.
Variable `cwl_runner_version` specifies the version of cwltool to install( or whatever tool is specified via `cwl_runner)`.