### PR TITLE
Roles for building bespin docker images during deployment

### DIFF
--- a/bespin_job_watcher/tasks/main.yml
+++ b/bespin_job_watcher/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Create bespin-job-watcher container
   docker_container:
-    image: dukegcb/bespin-job-watcher
+    image: "{{ bespin_settings.job_watcher.build.image_name }}:{{ bespin_settings.job_watcher.build.version }}"
     name: bespin-job-watcher
     volumes:
       - /etc/external/:/etc/external/

--- a/bespin_job_watcher/tasks/main.yml
+++ b/bespin_job_watcher/tasks/main.yml
@@ -28,7 +28,6 @@
       - "80:80"
       - "443:443"
       - "8080:8080"
-    pull: true
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -9,7 +9,6 @@
     name: bespin-lando
     volumes:
       - /etc/lando_config.yml:/etc/lando_config.yml
-    pull: false
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Create app container
   docker_container:
-    image: "lando-built-ansible:{{ bespin_settings.lando.version }}"
+    image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
     name: bespin-lando
     volumes:
       - /etc/lando_config.yml:/etc/lando_config.yml

--- a/bespin_lando/tasks/main.yml
+++ b/bespin_lando/tasks/main.yml
@@ -5,11 +5,11 @@
 
 - name: Create app container
   docker_container:
-    image: "dukegcb/bespin-lando:{{ bespin_settings.lando.version }}"
+    image: "lando-built-ansible:{{ bespin_settings.lando.version }}"
     name: bespin-lando
     volumes:
       - /etc/lando_config.yml:/etc/lando_config.yml
-    pull: true
+    pull: false
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_mailer/tasks/main.yml
+++ b/bespin_mailer/tasks/main.yml
@@ -10,10 +10,10 @@
 
 - name: Create app container
   docker_container:
-    image: dukegcb/bespin-mailer
+    image: "mailer-built-ansible:master"
     name: bespin-mailer
     env: "{{ web_environment }}"
-    pull: true
+    pull: false
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_mailer/tasks/main.yml
+++ b/bespin_mailer/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create app container
   docker_container:
-    image: "mailer-built-ansible:master"
+    image: "{{ bespin_settings.mailer.build.image_name }}:{{ bespin_settings.mailer.build.version }}"
     name: bespin-mailer
     env: "{{ web_environment }}"
     pull: false

--- a/bespin_mailer/tasks/main.yml
+++ b/bespin_mailer/tasks/main.yml
@@ -13,7 +13,6 @@
     image: "{{ bespin_settings.mailer.build.image_name }}:{{ bespin_settings.mailer.build.version }}"
     name: bespin-mailer
     env: "{{ web_environment }}"
-    pull: false
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_web/tasks/loaddata.yml
+++ b/bespin_web/tasks/loaddata.yml
@@ -20,8 +20,7 @@
   docker_container:
     command: "python manage.py {{ item }}"
     name: bespin-loaddata
-    image: "{{ bespin_settings.web.build.secondary_image_name}}:{{ bespin_settings.web.build.version }}-apache"
-    pull: true
+    image: "{{ bespin_settings.web.build.image_name}}:{{ bespin_settings.web.build.version }}-apache"
     state: started
     detach: false
     env: "{{ web_environment }}"
@@ -39,8 +38,7 @@
   docker_container:
     command: "python manage.py loaddata {{ bespin_settings.web.fixture_directory }}/{{ item }}"
     name: bespin-loaddata
-    image: "{{ bespin_settings.web.build.secondary_image_name}}:{{ bespin_settings.web.build.version }}-apache"
-    pull: true
+    image: "{{ bespin_settings.web.build.image_name}}:{{ bespin_settings.web.build.version }}-apache"
     state: started
     detach: false
     env: "{{ web_environment }}"

--- a/bespin_web/tasks/loaddata.yml
+++ b/bespin_web/tasks/loaddata.yml
@@ -20,7 +20,7 @@
   docker_container:
     command: "python manage.py {{ item }}"
     name: bespin-loaddata
-    image: "dukegcb/bespin-api:{{ bespin_settings.web.version }}-apache"
+    image: "{{ bespin_settings.web.build.secondary_image_name}}:{{ bespin_settings.web.build.version }}-apache"
     pull: true
     state: started
     detach: false
@@ -39,7 +39,7 @@
   docker_container:
     command: "python manage.py loaddata {{ bespin_settings.web.fixture_directory }}/{{ item }}"
     name: bespin-loaddata
-    image: "dukegcb/bespin-api:{{ bespin_settings.web.version }}-apache"
+    image: "{{ bespin_settings.web.build.secondary_image_name}}:{{ bespin_settings.web.build.version }}-apache"
     pull: true
     state: started
     detach: false

--- a/bespin_web/tasks/run-server.yml
+++ b/bespin_web/tasks/run-server.yml
@@ -26,7 +26,7 @@
 
 - name: Create app container
   docker_container:
-    image: "{{ bespin_settings.web.build.secondary_image_name}}:{{ bespin_settings.web.build.version }}-apache"
+    image: "{{ bespin_settings.web.build.image_name}}:{{ bespin_settings.web.build.version }}-apache"
     name: bespin-web
     env: "{{ web_environment }}"
     volumes:
@@ -35,7 +35,6 @@
     ports:
       - "80:80"
       - "443:443"
-    pull: true
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_web/tasks/run-server.yml
+++ b/bespin_web/tasks/run-server.yml
@@ -10,15 +10,7 @@
         mode=400
 
 # The bespin-api Docker image includes apache and is configured to serve the production-built
-# bespin-ui ember app from /srv/ui. The app is built using the build_ember_app role and should be placed
-# in bespin_settings.ui.srv_dir
-# That directory is mounted as a volume, so we can't simply delete / replace the directory otherwise
-# docker and apache can't find it.
-- name: Ensure directory exists for bespin-ui
-  file:
-    state: directory
-    path: "{{ bespin_settings.ui.srv_dir }}"
-
+# bespin-ui ember app from /srv/ui. That app is built by the build_ember_app, and placed in a docker volume
 - name: Create app container
   docker_container:
     image: "{{ bespin_settings.web.build.image_name}}:{{ bespin_settings.web.build.version }}-apache"
@@ -26,7 +18,7 @@
     env: "{{ web_environment }}"
     volumes:
       - /etc/external/:/etc/external/
-      - "{{ bespin_settings.ui.srv_dir }}:/srv/ui/"
+      - "bespin-ui-{{ bespin_settings.ui.build.version }}:/srv/ui/:ro"
     ports:
       - "80:80"
       - "443:443"

--- a/bespin_web/tasks/run-server.yml
+++ b/bespin_web/tasks/run-server.yml
@@ -26,7 +26,7 @@
 
 - name: Create app container
   docker_container:
-    image: "dukegcb/bespin-api:{{ bespin_settings.web.version }}-apache"
+    image: "{{ bespin_settings.web.build.secondary_image_name}}:{{ bespin_settings.web.build.version }}-apache"
     name: bespin-web
     env: "{{ web_environment }}"
     volumes:

--- a/bespin_web/tasks/run-server.yml
+++ b/bespin_web/tasks/run-server.yml
@@ -9,20 +9,15 @@
   copy: src="../../../files/{{ bespin_settings.web.ssl_key_file }}" dest="{{ bespin_settings.web.ssl_dir }}/privkey.pem"
         mode=400
 
-- name: Make ui directory
+# The bespin-api Docker image includes apache and is configured to serve the production-built
+# bespin-ui ember app from /srv/ui. The app is built using the build_ember_app role and should be placed
+# in bespin_settings.ui.srv_dir
+# That directory is mounted as a volume, so we can't simply delete / replace the directory otherwise
+# docker and apache can't find it.
+- name: Ensure directory exists for bespin-ui
   file:
     state: directory
     path: "{{ bespin_settings.ui.srv_dir }}"
-
-# Clearing out the directory manually because removing and recreating the directory left apache in a bad state (404 errors).
-- name: Clear out existing ui data
-  shell: /bin/rm -rf /srv/ui/*
-
-- name: Download bespin-ui release tar.gz
-  unarchive:
-    src: "{{ bespin_settings.ui.dist_base_url }}/{{ bespin_settings.ui.dist_version }}/{{ bespin_settings.ui.dist_filename }}"
-    dest: "{{ bespin_settings.ui.srv_dir }}"
-    remote_src: yes
 
 - name: Create app container
   docker_container:

--- a/build_docker_image/README.md
+++ b/build_docker_image/README.md
@@ -1,0 +1,42 @@
+# build\_docker\_image
+
+Ansible role for building a docker image from a git repo
+
+## Requirements
+
+Uses the [docker_image](https://docs.ansible.com/ansible/2.6/modules/docker_image_module.html) and [git](https://docs.ansible.com/ansible/2.6/modules/git_module.html) modules, so requires docker and git installed.
+
+## Usage
+
+This role is designed to be called just before deploying a docker container with the [docker_container](https://docs.ansible.com/ansible/2.6/modules/docker_container_module.html) module.
+
+It requires the following variables to build the docker image:
+
+- `repo_url`: URL of git repo containing a Dockerfile in the root.
+- `version`: tag, branch, or commit to check out from Git repo. Will also be used for the docker image tag
+- `image_name`: Name of the docker image to build.
+
+Optional variables for building a second image from the same repo:
+
+- `secondary_context`: Subdirectory in the repo to use as docker build context for secondary image.
+- `secondary_version`: Tag to use when building the secondary image.
+- `secondary_buildargs`: Dictionary of build arguments to pass to the secondary build
+
+## Examples:
+
+Build an image `lando:0.6.3` from the repo at `https://github.com/Duke-GCB/bespin-lando`
+
+    repo_url: https://github.com/Duke-GCB/bespin-lando
+    version: 0.6.3
+    image_name: lando
+
+Build `bespin-api:v1.5.2` then `bespin-api:v1.5.2-apache` from tag `v1.5.2` of `https://github.com/Duke-GCB/bespin-api`, the latter built from the `apache-docker` subdirectory
+
+    version: v1.5.2
+    repo_url: https://github.com/Duke-GCB/bespin-api
+    image_name: "bespin-api"
+    secondary_context: "apache-docker"
+    secondary_version: "v1.5.2-apache"
+    secondary_buildargs: { BASE_IMAGE: "bespin-api:v1.5.2" }
+
+To avoid repeating version numbers, use variables wherever possible.

--- a/build_docker_image/defaults/main.yml
+++ b/build_docker_image/defaults/main.yml
@@ -1,1 +1,1 @@
-local_repo_root: /build-docker-image-src
+local_repo_root: /tmp/build-docker-image-src

--- a/build_docker_image/defaults/main.yml
+++ b/build_docker_image/defaults/main.yml
@@ -1,0 +1,1 @@
+local_repo_path: /build-docker-image-src

--- a/build_docker_image/defaults/main.yml
+++ b/build_docker_image/defaults/main.yml
@@ -1,1 +1,1 @@
-local_repo_path: /build-docker-image-src
+local_repo_root: /build-docker-image-src

--- a/build_docker_image/tasks/main.yml
+++ b/build_docker_image/tasks/main.yml
@@ -1,22 +1,28 @@
 - name: Ensure directory exists for cloning git repo
   file:
     state: directory
-    path: "{{ local_repo_path }}/{{ image_name }}-{{ version }}"
+    path: "{{ local_repo_root }}/{{ image_name }}-{{ version }}"
 
-# Note that this checks out the git repo to the provided local repo
-# path and image name. it does not infer a subdirectory name from the
-# remote git repo like the default git mode.
-# We must use a somewhat unique name here so that one host can
-# support different image builds
+# Note that this checks out the git repo to a specific local directory based on the
+# provided image_name and version. it does not infer a subdirectory name from the
+# remote git repo like the default git mode. We must use a unique name here so that
+# one host can support distinct image builds
 - name: Clone the Git repo at the provided version
   git:
-    repo: "{{ repo_path }}"
-    dest: "{{ local_repo_path }}/{{ image_name }}-{{ version }}"
+    repo: "{{ repo_url }}"
+    dest: "{{ local_repo_root }}/{{ image_name }}-{{ version }}"
     version: "{{ version }}"
 
-# TODO: Only build the docker image if the git version changed.
 - name: Build a docker image
   docker_image:
-    path: "{{ local_repo_path }}/{{ image_name }}-{{ version }}"
+    path: "{{ local_repo_root }}/{{ image_name }}-{{ version }}"
     name: "{{ image_name }}"
     tag: "{{ version }}"
+
+- name: Build secondary image (if configured)
+  docker_image:
+    path: "{{ local_repo_root }}/{{ image_name }}-{{ version }}/{{ secondary_context }}"
+    name: "{{ secondary_image_name }}"
+    tag: "{{ secondary_version }}"
+    buildargs: "{{ secondary_buildargs }}"
+  when: secondary_context is defined and secondary_version is defined and secondary_buildargs is defined

--- a/build_docker_image/tasks/main.yml
+++ b/build_docker_image/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Ensure directory exists for cloning git repo
+  file:
+    state: directory
+    path: "{{ local_repo_path }}/{{ image_name }}-{{ version }}"
+
+# Note that this checks out the git repo to the provided local repo
+# path and image name. it does not infer a subdirectory name from the
+# remote git repo like the default git mode.
+# We must use a somewhat unique name here so that one host can
+# support different image builds
+- name: Clone the Git repo at the provided version
+  git:
+    repo: "{{ repo_path }}"
+    dest: "{{ local_repo_path }}/{{ image_name }}-{{ version }}"
+    version: "{{ version }}"
+
+# TODO: Only build the docker image if the git version changed.
+- name: Build a docker image
+  docker_image:
+    path: "{{ local_repo_path }}/{{ image_name }}-{{ version }}"
+    name: "{{ image_name }}"
+    tag: "{{ version }}"

--- a/build_docker_image/tasks/main.yml
+++ b/build_docker_image/tasks/main.yml
@@ -19,10 +19,15 @@
     name: "{{ image_name }}"
     tag: "{{ version }}"
 
-- name: Build secondary image (if configured)
+# This step is for the special case of bespin-api. As of 2018-10-24 it has two Dockerfiles
+# in the repo. One to build the django-serving image (not for production) and the second
+# to install Apache with mod_wsgi. The second image depends on the first, and should be
+# built as a second tag in the first image repo.
+- name: Build secondary image version (if configured)
   docker_image:
     path: "{{ local_repo_root }}/{{ image_name }}-{{ version }}/{{ secondary_context }}"
-    name: "{{ secondary_image_name }}"
+    name: "{{ image_name }}"
     tag: "{{ secondary_version }}"
     buildargs: "{{ secondary_buildargs }}"
+    pull: no # Do not pull, because the base image is likely a locally-built image that would not exist on Docker Hub.
   when: secondary_context is defined and secondary_version is defined and secondary_buildargs is defined

--- a/build_ember_app/README.md
+++ b/build_ember_app/README.md
@@ -8,7 +8,7 @@ Uses the [docker_container](https://docs.ansible.com/ansible/2.6/modules/docker_
 
 ## Usage
 
-This role uses a nodejs Docker image to build the application from source into a named docker volume..
+This role uses a nodejs Docker image to build the application from source into a named docker volume.
 build\_ember\_app is designed to run before [bespin_web](../bespin_web), where a Docker container running a web server serves a pre-built Ember application from a named docker volume.
 
 It requires the following variables to build the docker image:

--- a/build_ember_app/README.md
+++ b/build_ember_app/README.md
@@ -1,0 +1,32 @@
+# build\_ember\_app
+
+Ansible role for building an Ember application into a docker volume from a git repo
+
+## Requirements
+
+Uses the [docker_container](https://docs.ansible.com/ansible/2.6/modules/docker_container_module.html), [docker_volume](https://docs.ansible.com/ansible/2.6/modules/docker_volume_module.html) and [git](https://docs.ansible.com/ansible/2.6/modules/git_module.html) modules, so requires docker and git installed.
+
+## Usage
+
+This role uses a nodejs Docker image to build the application from source into a named docker volume..
+build\_ember\_app is designed to run before [bespin_web](../bespin_web), where a Docker container running a web server serves a pre-built Ember application from a named docker volume.
+
+It requires the following variables to build the docker image:
+
+- `repo_url`: URL of git repo containing an Ember application
+- `version`: tag, branch, or commit to check out from Git repo.
+- `repo_name`: Name of the application to build. Just used for local directory uniqueness (e.g. so that the same host can build two different ember apps)
+- `target_volume`: Name of docker volume to create and place built application. Note that this is a named docker volume, not a host path.
+- `build_environment`: Dictionary of environment variables and values to provide at build-time
+
+## Examples:
+
+Build the ember app from the tag `v0.6.3` the repo at `https://github.com/Duke-GCB/bespin-ui` using the production `JOB_WATCHER_URL`. Place the built `index.html` and other assets in a volume called `bespin-ui-v0.6.3`
+
+    repo_url: https://github.com/Duke-GCB/bespin-ui
+    version: v0.6.3
+    repo_name: bespin-ui
+    target_volume: bespin-ui-v0.6.3
+    build_environment: { JOB_WATCHER_URL: wss://bespin-ws-prod.gcb.duke.edu }
+
+To avoid repeating version numbers, use variables wherever possible.

--- a/build_ember_app/defaults/main.yml
+++ b/build_ember_app/defaults/main.yml
@@ -1,0 +1,3 @@
+local_repo_root: /tmp/build-ember-app-src
+ember_build_image: node:8
+ember_build_cmd: "sh -c 'npm install && npm run build -- --environment production'"

--- a/build_ember_app/tasks/main.yml
+++ b/build_ember_app/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: Ensure directory exists for cloning git repo
+  file:
+    state: directory
+    path: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}"
+
+# Note that this checks out the git repo to a specific local directory based on the
+# provided image_name and version. it does not infer a subdirectory name from the
+# remote git repo like the default git mode. We must use a unique name here so that
+# one host can support distinct ember builds
+- name: Clone the Git repo at the provided version
+  git:
+    repo: "{{ repo_url }}"
+    dest: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}"
+    version: "{{ version }}"
+
+- name: Run the ember build inside Docker
+  docker_container:
+    command: "{{ ember_build_cmd }}"
+    name: "ember-builder-{{ repo_name }}-{{ version }}"
+    image: "{{ ember_build_image }}"
+    state: started
+    detach: false
+    env: "{{ build_environment }}"
+    volumes:
+      - "{{ local_repo_root }}/{{ repo_name }}-{{ version }}:/src"
+    working_dir: "/src"
+
+- name: Remove loaddata container
+  docker_container:
+    name: "ember-builder-{{ repo_name }}-{{ version }}"
+    state: absent
+
+- name: Copy the default output directory (dist) to desired location
+  copy:
+    remote_src: true
+    src: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}/dist"
+    dest: "{{ target_directory }}"
+
+- name: Remove built artifact
+  file:
+    path: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}/dist"
+    state: absent

--- a/build_ember_app/tasks/main.yml
+++ b/build_ember_app/tasks/main.yml
@@ -18,6 +18,11 @@
     version: "{{ version }}"
     force: yes
 
+- name: Create a docker volume to hold the built application
+  docker_volume:
+    name: "{{ target_volume }}"
+    state: present
+
 - name: Run the ember build inside Docker
   docker_container:
     command: "{{ ember_build_cmd }}"
@@ -28,6 +33,7 @@
     env: "{{ build_environment }}"
     volumes:
       - "{{ local_repo_root }}/{{ repo_name }}-{{ version }}:/src"
+      - "{{ target_volume }}:/src/dist"
     working_dir: "/src"
 
 # After the build, package.lock will have been updated
@@ -35,16 +41,3 @@
   docker_container:
     name: "ember-builder-{{ repo_name }}-{{ version }}"
     state: absent
-
-- name: Ensure target directory is present
-  file:
-    state: directory
-    path: "{{ target_directory }}"
-
-# Clearing out the directory manually because removing and recreating the directory left apache in a bad state (404 errors).
-# Using -r to remove recursively, and -f to ignore empty directories.
-- name: Clear target directory
-  shell: "/bin/rm -rf {{ target_directory }}/*"
-
-- name: Move contents of built dist directory to target directory
-  shell: "mv {{ local_repo_root }}/{{ repo_name }}-{{ version }}/dist/* {{ target_directory }}"

--- a/build_ember_app/tasks/main.yml
+++ b/build_ember_app/tasks/main.yml
@@ -7,11 +7,16 @@
 # provided image_name and version. it does not infer a subdirectory name from the
 # remote git repo like the default git mode. We must use a unique name here so that
 # one host can support distinct ember builds
+#
+# We use force because npm install will update package-lock.json and leave it modified
+# in the working directory. Subsequent git actions would fail because of those local changes
+# without force
 - name: Clone the Git repo at the provided version
   git:
     repo: "{{ repo_url }}"
     dest: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}"
     version: "{{ version }}"
+    force: yes
 
 - name: Run the ember build inside Docker
   docker_container:
@@ -25,18 +30,21 @@
       - "{{ local_repo_root }}/{{ repo_name }}-{{ version }}:/src"
     working_dir: "/src"
 
+# After the build, package.lock will have been updated
 - name: Remove loaddata container
   docker_container:
     name: "ember-builder-{{ repo_name }}-{{ version }}"
     state: absent
 
-- name: Copy the default output directory (dist) to desired location
-  copy:
-    remote_src: true
-    src: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}/dist"
-    dest: "{{ target_directory }}"
-
-- name: Remove built artifact
+- name: Ensure target directory is present
   file:
-    path: "{{ local_repo_root }}/{{ repo_name }}-{{ version }}/dist"
-    state: absent
+    state: directory
+    path: "{{ target_directory }}"
+
+# Clearing out the directory manually because removing and recreating the directory left apache in a bad state (404 errors).
+# Using -r to remove recursively, and -f to ignore empty directories.
+- name: Clear target directory
+  shell: "/bin/rm -rf {{ target_directory }}/*"
+
+- name: Move contents of built dist directory to target directory
+  shell: "mv {{ local_repo_root }}/{{ repo_name }}-{{ version }}/dist/* {{ target_directory }}"

--- a/build_ember_app/tasks/main.yml
+++ b/build_ember_app/tasks/main.yml
@@ -36,7 +36,6 @@
       - "{{ target_volume }}:/src/dist"
     working_dir: "/src"
 
-# After the build, package.lock will have been updated
 - name: Remove loaddata container
   docker_container:
     name: "ember-builder-{{ repo_name }}-{{ version }}"

--- a/list_docker_containers/tasks/main.yml
+++ b/list_docker_containers/tasks/main.yml
@@ -1,7 +1,18 @@
+- name: Check if docker is installed
+  command: which docker
+  register: which_docker
+  failed_when: no
+  changed_when: no
+
 - name: List running docker containers
   command: "{% raw %}docker ps --format '{{.Names}}, {{.Image}}'{% endraw %}"
   register: docker_ps
+  when: which_docker.rc == 0
+
 - set_fact:
     containers: "{{ docker_ps.stdout_lines}}"
+  when: which_docker.rc == 0
+
 - debug:
     var: containers
+  when: which_docker.rc == 0

--- a/list_docker_containers/tasks/main.yml
+++ b/list_docker_containers/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: List running docker containers
+  command: "{% raw %}docker ps --format '{{.Names}}, {{.Image}}'{% endraw %}"
+  register: docker_ps
+- set_fact:
+    containers: "{{ docker_ps.stdout_lines}}"
+- debug:
+    var: containers


### PR DESCRIPTION
Updates and additions to bespin roles to allow for deployment from source without waiting for Docker Hub automated builds or CI Ember builds.

Tested on bespin-dev with updated playbook in matching gcb-ansible branch.

- Adds `build_docker_image` role to clone a git repo and build a docker image
- Adds `build_ember_app` role to clone a git repo and build an ember application using Docker into a docker volume
- Adds `list_docker_containers` role to report a list of running docker containers and their images:versions
- Updates bespin roles to build images on-demand from source+Dockerfile rather than pulling images from Docker Hub
