### PR TITLE
Allow custom jupyterhub environment in spawner slurm script

### DIFF
--- a/jupyterhub/tasks/main.yml
+++ b/jupyterhub/tasks/main.yml
@@ -285,8 +285,24 @@
       #SBATCH --uid={username}
       #SBATCH --get-user-env=L
       #SBATCH {options}
-      {{ load_jupyterhub_path }}
-      which jupyterhub-singleuser
+
+      if [ -f {homedir}/{{spawner_rc_file_name}} ]; then
+        echo "Sourcing {homedir}/{{spawner_rc_file_name}}"
+        source {homedir}/{{spawner_rc_file_name}}
+        JHS_CMD=$(which jupyterhub-singleuser)
+        RESULT=$?
+        if [ $RESULT -eq 0 ] ; then
+          echo "Using $JHS_CMD"
+        else
+          echo "Unable to launch jupyter notebook - Spawner could not locate 'jupyterhub-singleuser' command in PATH."
+          echo "If you intend to use a custom environment, please visit https://wiki.duke.edu/display/HAR/Using+JupyterHub+on+HARDAC for more information."
+          echo "You can also remove your {{spawner_rc_file_name}} file and use the default environment."
+          exit 1
+        fi
+      else
+        # No spawner rc file, activate the default environment providing jupyterhub-singleuser
+        {{ load_jupyterhub_path }}
+      fi
       {cmd}
       """
 

--- a/jupyterhub/vars/main.yml
+++ b/jupyterhub/vars/main.yml
@@ -1,1 +1,2 @@
 ---
+spawner_rc_file_name: '.spawnerrc'


### PR DESCRIPTION
This change will update the jupyterhub slurm script template to source a .spawnerrc file in the user's home directory instead of loading the default environment
If the custom environment does not provide a jupyterhub-singleuser command, an error message is displayed