### PR TITLE
Adds roles to create/delete/format openstack volumes

### DIFF
--- a/create-volume/defaults/main.yml
+++ b/create-volume/defaults/main.yml
@@ -1,0 +1,1 @@
+availability_zone: nova

--- a/create-volume/tasks/main.yml
+++ b/create-volume/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Create volume
+  os_volume:
+    state: present
+    display_name: "{{ volume_name }}"
+    size: "{{ size_gb }}"
+    availability_zone: "{{ availability_zone }}"
+    display_description: "{{ volume_description }}"
+- name: Atach the volume to server.
+  os_server_volume:
+    state: present
+    server: "{{ server_name }}"
+    volume: "{{ volume_name }}"
+  register: attached_volume
+- name: Record volume device id
+  set_fact:
+    device_id: "{{ attached_volume.attachments[0].device }}"
+- name: Debug attached_volume
+  debug:
+    var: device_id
+

--- a/delete-volume/defaults/main.yml
+++ b/delete-volume/defaults/main.yml
@@ -1,0 +1,1 @@
+availability_zone: nova

--- a/delete-volume/tasks/main.yml
+++ b/delete-volume/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Detach the volume from server.
+  os_server_volume:
+    state: absent
+    server: "{{ server_name }}"
+    volume: "{{ volume_name }}"
+- name: Delete volume
+  os_volume:
+    state: absent
+    display_name: "{{ volume_name }}"
+    availability_zone: "{{ availability_zone }}"

--- a/format-volume/defaults/main.yml
+++ b/format-volume/defaults/main.yml
@@ -1,0 +1,3 @@
+owner: root
+group: root
+mode: 0770

--- a/format-volume/tasks/main.yml
+++ b/format-volume/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Create local directory for mount point.
+  file:
+    path: "{{ mount_point }}"
+    state: directory
+- name: Make primary partition
+  parted:
+    device: "{{ device_id }}"
+    number: 1
+    label: gpt
+    part_type: primary
+    state: present
+    part_start: 0%
+    part_end: 100%
+- name: Create a ext4 format filesystem.
+  filesystem:
+    fstype: ext4
+    dev: "{{ device_id }}1"
+- name: Get UUID for device.
+  command: blkid -s UUID -o value  "{{ device_id }}1"
+  register: disk_blkid
+  changed_when: False
+- name: Mount device by UUID.
+  mount:
+    # disabling backup for now since it requires ansible 2.5 and I only have 2.4
+#    backup: yes
+    path: "{{ mount_point }}"
+    src: UUID={{ disk_blkid.stdout }}
+    fstype: ext4
+    state: mounted
+- name: Change permissions on newly created directory.
+  file:
+    owner: "{{ owner }}"
+    group: "{{ group }}"
+    mode: "{{ mode }}"
+    recurse: yes
+    path: "{{ mount_point }}"


### PR DESCRIPTION
Roles copied out from https://github.com/Duke-GCB/volume_automation/tree/master/roles. Replaced default owner with root/root as this should be provided by inventory/group_vars