### PR TITLE
Install nodejs in bespin_lando_worker

### DIFF
--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -9,6 +9,7 @@
     packages:
     - nfs-common
     - libssl-dev
+    - nodejs
 
 - pip:
     name: "git+git://github.com/Duke-GCB/lando.git@{{ lando_version }}"


### PR DESCRIPTION
cwltool uses [nodejs locally if installed](https://github.com/common-workflow-language/cwltool/blob/592a7e6c5e10b96a3b15567bc1cdb3c8b89e2976/cwltool/sandboxjs.py#L62-L75). If not, it runs nodejs in Docker, which can lead to lots of additional docker containers.

This change installs nodejs into the lando worker image, so that worker VMs don't need to create those extra containers