### PR TITLE
Update bespin_lando_worker to install lando from PyPI

### DIFF
--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -11,7 +11,8 @@
     - libssl-dev
     - nodejs
 
-- pip:
+- name: Install lando via pip
+  pip:
     name: lando
     version: "{{ lando_version }}"
     executable: pip3
@@ -21,16 +22,19 @@
   register: which_lando_worker
   changed_when: no
 
-- pip:
+- name: Install html5lib via pip
+  pip:
     name: html5lib
     executable: pip3
 
-- pip:
+- name: Install CWL runner
+  pip:
     name: "{{ cwl_runner }}"
     version: "{{ cwl_runner_version }}"
     executable: pip3
 
-- file:
+- name: Make lando work directory
+  file:
     dest: "{{ lando_work_directory }}"
     state: directory
     owner: ubuntu
@@ -52,7 +56,8 @@
       [Install]
       WantedBy=multi-user.target
 
-- service:
+- name: Start lando_worker service
+  service:
     name: lando_worker
     state: started
     enabled: yes

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -12,8 +12,8 @@
     - nodejs
 
 - pip:
-    name: "git+git://github.com/Duke-GCB/lando.git@{{ lando_version }}"
-    editable: false
+    name: lando
+    version: "{{ lando_version }}"
     executable: pip3
 
 - name: Check where lando_worker has been installed to


### PR DESCRIPTION
Now that lando is on PyPI, we can install it from there instead of github repo