### PR TITLE
Role to remove unused docker containers/images

### DIFF
--- a/prune_docker/README.md
+++ b/prune_docker/README.md
@@ -19,9 +19,9 @@ The following variables can be set, butdefault to `yes`:
 ## Example:
 
 ```
-    - role: prune_docker
-      become: yes
+  roles:
+    - name: prune_docker
       vars:
-        prune_containers: yes
         prune_images: no
+        prune_containers: yes
 ```

--- a/prune_docker/README.md
+++ b/prune_docker/README.md
@@ -1,0 +1,27 @@
+# prune\_docker
+
+Removes unused docker containers and images on a host
+
+## Requirements
+
+Docker must be running on the host where this role is deployed.
+Requires either `become` privilege escalation or execution by a user with access to docker (e.g. in `docker` group)
+
+## Usage
+
+Run after deploying a new image to clean up old unused images and containers
+
+The following variables can be set, butdefault to `yes`:
+
+- `prune_containers`: If yes, stopped containers will be pruned
+- `prune_images`: If yes, unused images will be pruned
+
+## Example:
+
+```
+    - role: prune_docker
+      become: yes
+      vars:
+        prune_containers: yes
+        prune_images: no
+```

--- a/prune_docker/defaults/main.yml
+++ b/prune_docker/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+prune_images: yes
+prune_containers: yes

--- a/prune_docker/tasks/main.yml
+++ b/prune_docker/tasks/main.yml
@@ -3,13 +3,29 @@
 # rather than `docker system prune`, since we do not want to
 # remove volumes, networks, or build cache
 
-# First remove all stopped containers to free up images
+- name: Check if docker is installed
+  command: which docker
+  register: which_docker
+  failed_when: no
+  changed_when: no
+
+# Remove all stopped containers to free up images
 # that are only used by stopped containers
+# The force flag only used to suppress the confirmation message
 - name: Prune stopped containers
-  command: "docker container prune"
-  when: prune_containers
+  command: "docker container prune -f"
+  register: container_prune_result
+  when: prune_containers and which_docker.rc == 0
+
+- debug: msg="{{ container_prune_result.stdout_lines }}"
+  when: prune_containers and which_docker.rc == 0
 
 # Now remove all images not used by a container
+# The force flag only used to suppress the confirmation message
 - name: Prune unused images
-  command: "docker image prune -a"
-  when: prune_images
+  command: "docker image prune -a -f"
+  register: image_prune_result
+  when: prune_images and which_docker.rc == 0
+
+- debug: msg="{{ image_prune_result.stdout_lines }}"
+  when: prune_images and which_docker.rc == 0

--- a/prune_docker/tasks/main.yml
+++ b/prune_docker/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# This role uses individual docker <noun> prune commands
+# rather than `docker system prune`, since we do not want to
+# remove volumes, networks, or build cache
+
+# First remove all stopped containers to free up images
+# that are only used by stopped containers
+- name: Prune stopped containers
+  command: "docker container prune"
+  when: prune_containers
+
+# Now remove all images not used by a container
+- name: Prune unused images
+  command: "docker image prune -a"
+  when: prune_images


### PR DESCRIPTION
- Adds `prune_docker` role accepting variables `prune_images` and `prune_containers`
- By default, both are `yes` and this role will remove all stopped containers from a host and delete any unused images
- Uses docker prune commands and prints output with `debug` to show what's been removed/reclaimed
- This role is intended to be used after deploying applications with `build_docker_image`