### PR TITLE
Adds `lando_install_source` variable to install lando from GitHub

### DIFF
--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -1,4 +1,5 @@
-lando_version: master
+lando_install_source: PyPI
+lando_github_version: master
 cwl_runner: cwltool
 cwl_runner_version: latest
 lando_work_directory: /work

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -11,11 +11,19 @@
     - libssl-dev
     - nodejs
 
-- name: Install lando via pip
+- name: Install lando from PyPI
   pip:
     name: lando
     version: "{{ lando_version }}"
     executable: pip3
+  when: lando_install_source == 'PyPI'
+
+- name: Install lando from git
+  pip:
+    name: "git+git://github.com/Duke-GCB/lando.git@{{ lando_github_version }}"
+    editable: false
+    executable: pip3
+  when: lando_install_source == 'GitHub'
 
 - name: Check where lando_worker has been installed to
   command: which lando_worker


### PR DESCRIPTION
During development, it's useful to build an image installing lando from a branch on github.