### PR TITLE
use lando-util in bespin lando worker

### DIFF
--- a/bespin_lando/templates/lando_config.yml.j2
+++ b/bespin_lando/templates/lando_config.yml.j2
@@ -15,3 +15,7 @@ bespin_api:
   url: "{{ bespin_settings.web.url }}"
   token: "{{ bespin_settings.web.lando_token }}"
 log_level: "{{ bespin_settings.lando.log_level}}"
+commands:
+  stage_data_command: {{ bespin_settings.lando.stage_data_command | to_json }}
+  organize_output_command: {{ bespin_settings.lando.organize_output_command | to_json }}
+  save_output_command: {{ bespin_settings.lando.save_output_command | to_json }}

--- a/bespin_lando_worker/README.md
+++ b/bespin_lando_worker/README.md
@@ -1,27 +1,41 @@
 # bespin_lando_worker
 
-Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) in worker configuration along with cwltool.
+Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) in worker configuration along with cwltool and a utility package used for data staging/etc.
 
 This role installs the following:
 - **lando** - Code that will read messages related to staging data, running a specific workflow, and storing output
 - **cwltool** - Program to use for running the workflow, cwltool can be overridden if the tool is installable via pip3.
+- **lando-util** - Utility program used to use for staging data, organizing output and uploading results by default this is [lando-util](https://github.com/Duke-GCB/lando-util).
 
 This role sets up lando as a service and creates a nfs mount.
-Lando is installed directly from github repository.
-cwltool is installed via pypi release.
+By default lando, cwltool and lando-util are installed via pip.
+
+## Required fields
+- `lando_version` version of lando to install from pypi
+- `cwl_runner_version` version of cwltool to install from pypi
+- `util_package_version` version of lando-util to install from pypi
+
+## Optional fields
+- `lando_install_source` defaults to `PyPI` other supported value is `GitHub`
+- `lando_github_version` branch to install from github when `lando_install_source` is set to `GitHub`
+- `cwl_runner` name of workflow runner software to install from pypi (defaults to `cwltool`)
+- `util_package_name` name of the utility package to install from pypi (defaults to `lando-util`)
+- `lando_work_directory` WorkingDirectory used for lando-worker service (defaults to `/work`)
+- `worker_mount_name` - name of nfs to mount (defaults to `/data`)
+- `worker_mount_src`- src nfs to mount (defaults to `bespin-nfs:/mnt/bespin_datasets`)
 
 ## Dependencies
 None
 
 ## Usage
 
-By default deploys latest lando and cwltool.
-Users can select a specific version in a playbook like so:
+Example role that installs with required specific versions:
 ```
 ...
   roles:
     - role: bespin_lando_worker
       lando_version: 0.9.3
       cwl_runner_version: 1.0.20180912090223
+      util_package_version: 0.5.0
 ...
 ```

--- a/bespin_lando_worker/defaults/main.yml
+++ b/bespin_lando_worker/defaults/main.yml
@@ -5,3 +5,4 @@ cwl_runner_version: latest
 lando_work_directory: /work
 worker_mount_name: /data
 worker_mount_src: bespin-nfs:/mnt/bespin_datasets
+util_package_name: lando-util

--- a/bespin_lando_worker/tasks/main.yml
+++ b/bespin_lando_worker/tasks/main.yml
@@ -30,6 +30,12 @@
   register: which_lando_worker
   changed_when: no
 
+- name: Install utility package from PyPI
+  pip:
+    name: "{{ util_package_name }}"
+    version: "{{ util_package_version }}"
+    executable: pip3
+
 - name: Install html5lib via pip
   pip:
     name: html5lib


### PR DESCRIPTION
Adds command settings config to lando based on bespin_settings (this specifies the lando-util commands to run). Changes bespin_lando_worker to install a utility package with the default being lando-util.