### PR TITLE
lando k8s multi tenant

### DIFF
--- a/bespin_lando_k8s/README.md
+++ b/bespin_lando_k8s/README.md
@@ -3,12 +3,14 @@
 Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) as a service for running k8s jobs.
 Supports deploying multiple lando instances for running jobs on multiple clusters.
 
+For each cluster this role will
 - Writes a config file used by the services based on `bespin_settings`.
 - Creates a docker container that will run `lando.k8s.lando` to run jobs in k8s 
 - Creates a docker container that will run `lando.k8s.watcher` to watches k8s jobs/send messages to the `lando.k8s.lando` container
 
 ## Required fields
-- `bespin_settings` dicitionary of settings used to deploy lando including the image name and tag
+- `bespin_settings` dictionary of settings used to deploy lando.k8s.* services. 
+For each item in the `bespin_settings.k8s_clusters` dictionary the a
 - `k8s_cluster_name` a unique name for this cluster, used as key for reading cluster specific 
 settings from `bespin_settings.k8s_clusters` dictionary.
 
@@ -23,7 +25,6 @@ Example role that installs a lando server and watcher with the name "hardspin":
   roles:
     - role: bespin_lando_k8s
       vars:
-        k8s_cluster_name: "hardspin"
         bespin_settings:
           lando:
              build:

--- a/bespin_lando_k8s/README.md
+++ b/bespin_lando_k8s/README.md
@@ -1,6 +1,51 @@
 # bespin_lando_k8s
 
-Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) as services for running k8s jobs.
-- Writes a config file `/etc/lando_k8s_config.yml` based on `bespin_settings`.
+Ansible role for deploying [lando](https://github.com/Duke-GCB/lando) as a service for running k8s jobs.
+Supports deploying multiple lando instances for running jobs on multiple clusters.
+
+- Writes a config file used by the services based on `bespin_settings`.
 - Creates a docker container that will run `lando.k8s.lando` to run jobs in k8s 
 - Creates a docker container that will run `lando.k8s.watcher` to watches k8s jobs/send messages to the `lando.k8s.lando` container
+
+## Required fields
+- `bespin_settings` dicitionary of settings used to deploy lando including the image name and tag
+- `k8s_cluster_name` a unique name for this cluster, used as key for reading cluster specific 
+settings from `bespin_settings.k8s_clusters` dictionary.
+
+## Dependencies
+None
+
+## Usage
+
+Example role that installs a lando server and watcher with the name "hardspin":
+```
+...
+  roles:
+    - role: bespin_lando_k8s
+      vars:
+        k8s_cluster_name: "hardspin"
+        bespin_settings:
+          lando:
+             build:
+               image_name: "lando"
+               version: "master"
+          rabbit:
+            host: "somehost"
+            username: "lando"
+            password: "secret"
+            worker_username: "worker"
+            worker_password: "secret"
+          web:
+            token: "bespin_api_token"
+            url: "bespin_api_url"
+          k8s_clusters:
+            hardspin:
+              listen_queue: "hardspin_queue"
+            host: "k8shost"
+            token: "k8s_access_token"
+            namespace: "k8s_namespace_to_run_jobs_under"
+            verify_ssl: True
+            verify_ssl: True
+            config_file_data: {} # additional config added to the end of the lando config file
+...
+```

--- a/bespin_lando_k8s/tasks/create-services.yml
+++ b/bespin_lando_k8s/tasks/create-services.yml
@@ -8,7 +8,7 @@
     image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
     name: "bespin-lando-k8s-{{ k8s_cluster_name }}"
     volumes:
-      - "{{ lando_config_path }}:{{ lando_config_path }}"
+      - "{{ lando_config_path }}:{{ lando_config_path }}:ro"
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always
@@ -19,7 +19,7 @@
     image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
     name: "bespin-watcher-k8s-{{ k8s_cluster_name }}"
     volumes:
-      - "{{ lando_config_path }}:{{ lando_config_path }}"
+      - "{{ lando_config_path }}:{{ lando_config_path }}:ro"
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always

--- a/bespin_lando_k8s/tasks/create-services.yml
+++ b/bespin_lando_k8s/tasks/create-services.yml
@@ -1,0 +1,26 @@
+- name: Setup lando config
+  template:
+    src: lando_k8s_config.yml.j2
+    dest: "{{ lando_config_path }}"
+
+- name: Create lando kubernetes job runner container
+  docker_container:
+    image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
+    name: "bespin-lando-k8s-{{ k8s_cluster_name }}"
+    volumes:
+      - "{{ lando_config_path }}:{{ lando_config_path }}"
+    etc_hosts: "{{ bespin_hosts_list }}"
+    state: started
+    restart_policy: always
+    command: python -m lando.k8s.lando "{{ lando_config_path }}"
+
+- name: Create lando kubernetes watcher container
+  docker_container:
+    image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
+    name: "bespin-watcher-k8s-{{ k8s_cluster_name }}"
+    volumes:
+      - "{{ lando_config_path }}:{{ lando_config_path }}"
+    etc_hosts: "{{ bespin_hosts_list }}"
+    state: started
+    restart_policy: always
+    command: python -m lando.k8s.watcher "{{ lando_config_path }}"

--- a/bespin_lando_k8s/tasks/main.yml
+++ b/bespin_lando_k8s/tasks/main.yml
@@ -1,30 +1,7 @@
-- set_fact:
-    lando_config_path: "/etc/lando_{{ k8s_cluster_name }}_config.yml"
-    lando_k8s: "{{ bespin_settings.k8s_clusters[k8s_cluster_name] }}"
-
-- name: Setup lando config
-  template:
-    src: lando_k8s_config.yml.j2
-    dest: "{{ lando_config_path }}"
-
-- name: Create lando kubernetes job runner container
-  docker_container:
-    image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
-    name: "bespin-lando-k8s-{{ k8s_cluster_name }}"
-    volumes:
-      - "{{ lando_config_path }}:{{ lando_config_path }}"
-    etc_hosts: "{{ bespin_hosts_list }}"
-    state: started
-    restart_policy: always
-    command: python -m lando.k8s.lando "{{ lando_config_path }}"
-
-- name: Create lando kubernetes watcher container
-  docker_container:
-    image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
-    name: "bespin-watcher-k8s-{{ k8s_cluster_name }}"
-    volumes:
-      - "{{ lando_config_path }}:{{ lando_config_path }}"
-    etc_hosts: "{{ bespin_hosts_list }}"
-    state: started
-    restart_policy: always
-    command: python -m lando.k8s.watcher "{{ lando_config_path }}"
+- name: Create lando k8s services for each item in bespin_settings.k8s_clusters
+  include_tasks: create-services.yml
+  vars:
+    k8s_cluster_name: "{{ item.key }}"
+    lando_config_path: "/etc/lando_{{ item.key }}_config.yml"
+    lando_k8s: "{{ item.value }}"
+  with_dict:  "{{ bespin_settings.k8s_clusters }}"

--- a/bespin_lando_k8s/tasks/main.yml
+++ b/bespin_lando_k8s/tasks/main.yml
@@ -1,26 +1,30 @@
+- set_fact:
+    lando_config_path: "/etc/lando_{{ k8s_cluster_name }}_config.yml"
+    lando_k8s: "{{ bespin_settings.k8s_clusters[k8s_cluster_name] }}"
+
 - name: Setup lando config
   template:
     src: lando_k8s_config.yml.j2
-    dest: /etc/lando_k8s_config.yml
+    dest: "{{ lando_config_path }}"
 
 - name: Create lando kubernetes job runner container
   docker_container:
     image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
-    name: bespin-lando-k8s
+    name: "bespin-lando-k8s-{{ k8s_cluster_name }}"
     volumes:
-      - /etc/lando_k8s_config.yml:/etc/lando_k8s_config.yml
+      - "{{ lando_config_path }}:{{ lando_config_path }}"
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always
-    command: python -m lando.k8s.lando /etc/lando_k8s_config.yml
+    command: python -m lando.k8s.lando "{{ lando_config_path }}"
 
 - name: Create lando kubernetes watcher container
   docker_container:
     image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
-    name: bespin-watcher-k8s
+    name: "bespin-watcher-k8s-{{ k8s_cluster_name }}"
     volumes:
-      - /etc/lando_k8s_config.yml:/etc/lando_k8s_config.yml
+      - "{{ lando_config_path }}:{{ lando_config_path }}"
     etc_hosts: "{{ bespin_hosts_list }}"
     state: started
     restart_policy: always
-    command: python -m lando.k8s.watcher /etc/lando_k8s_config.yml
+    command: python -m lando.k8s.watcher "{{ lando_config_path }}"

--- a/bespin_lando_k8s/templates/lando_k8s_config.yml.j2
+++ b/bespin_lando_k8s/templates/lando_k8s_config.yml.j2
@@ -2,18 +2,18 @@ work_queue:
   host: "{{ bespin_settings.rabbit.host }}"
   username: "{{ bespin_settings.rabbit.username }}"
   password: "{{ bespin_settings.rabbit.password }}"
-  listen_queue: "{{ bespin_settings.rabbit.listen_queue_k8s }}"
   worker_username: "{{ bespin_settings.rabbit.worker_username }}"
   worker_password: "{{ bespin_settings.rabbit.worker_password }}"
+  listen_queue: "{{ lando_k8s.listen_queue }}"
 
 cluster_api_settings:
-  host: "{{ bespin_settings.k8s.host }}"
-  token: "{{ bespin_settings.k8s.token }}"
-  namespace: "{{ bespin_settings.k8s.namespace }}"
-  verify_ssl: {{ bespin_settings.k8s.verify_ssl }}
+  host: "{{ lando_k8s.host }}"
+  token: "{{ lando_k8s.token }}"
+  namespace: "{{ lando_k8s.namespace }}"
+  verify_ssl: {{ lando_k8s.verify_ssl }}
 
 bespin_api:
   token: "{{ bespin_settings.web.lando_token }}"
   url: "{{ bespin_settings.web.url }}"
 
-{{ bespin_settings.lando_k8s | to_yaml }}
+{{ lando_k8s.config_file_data | to_yaml }}


### PR DESCRIPTION
Changes `bespin_lando_k8s` role  to allow bespin to use multiple k8s clusters.
This change adds a `k8s_clusters` field to the `bespin_settings` dictionary.
`k8s_clusters` is a dictionary where the key is a name to assign to the cluster.
See https://github.com/Duke-GCB/gcb-ansible-roles/blob/lando-k8s-multi-tenant/bespin_lando_k8s/README.md for more details.