### PR TITLE
Add /download/ to datadelivery proxy locations

### DIFF
--- a/d4s2_webapp/files/nginx.conf
+++ b/d4s2_webapp/files/nginx.conf
@@ -28,7 +28,7 @@ http {
       proxy_pass http://ui:80;
     }
 
-    location ~ ^/(admin|ownership|auth|api|api-auth|api-auth-token|accounts|static)/  {
+    location ~ ^/(admin|ownership|auth|api|api-auth|api-auth-token|accounts|static|download)/  {
       proxy_pass http://d4s2-app:8000;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;


### PR DESCRIPTION
Updates the nginx proxy config so that requests to `/download/` on a datadelivery server are routed to the d4s2 container (rather than the datadelivery-ui container)