### PR TITLE
Add d4s2-download container for datadelivery to correctly service streaming downloads

### DIFF
--- a/d4s2_webapp/files/nginx.conf
+++ b/d4s2_webapp/files/nginx.conf
@@ -28,14 +28,21 @@ http {
       proxy_pass http://ui:80;
     }
 
-    location ~ ^/(admin|ownership|auth|api|api-auth|api-auth-token|accounts|static|download)/  {
+    location ~ ^/(admin|ownership|auth|api|api-auth|api-auth-token|accounts|static)/ {
       proxy_pass http://d4s2-app:8000;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+    }
+
+    location ~ ^/(download)/ {
+      proxy_pass http://d4s2-download:8000;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
       proxy_buffering off;  ## Disable proxy buffering for downloads
     }
-
   }
 }

--- a/d4s2_webapp/files/nginx.conf
+++ b/d4s2_webapp/files/nginx.conf
@@ -34,6 +34,7 @@ http {
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_buffering off;  ## Disable proxy buffering for downloads
     }
 
   }

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -31,6 +31,16 @@
     state: started
     restart_policy: always
   tags: ['api']
+- name: Create download service container
+  docker_container:
+    image: "{{ d4s2_docker_image }}"
+    name: d4s2-download
+    networks:
+      - name: "{{ d4s2_docker_network }}"
+    env: "{{ d4s2_docker_env | combine({'GUNICORN_CMD_ARGS':'--worker-class gevent'})}}"
+    pull: false
+    state: started
+    restart_policy: always
 - name: Create task processor container
   docker_container:
     image: "{{ d4s2_docker_image }}"


### PR DESCRIPTION
Moves the datadelivery `/download` location to be serviced by an additional d4s2 container named `d4s2-download`. This location disables proxy buffering and uses configures gunicorn to use `--worker-class gevent` as recommended by  https://docs.gunicorn.org/en/stable/deploy.html?highlight=streaming.

Leaves the other d4s2 API locations to be served by d4s2-app and use gunicorn sync workers.

Requires https://github.com/Duke-GCB/D4S2/pull/215 