### PR TITLE
Fixes 503 errors from proxy when deploying datadelivery

### DIFF
--- a/d4s2_webapp/handlers/main.yml
+++ b/d4s2_webapp/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart web
+  docker_container:
+    name: web
+    state: started
+    restart: yes

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -30,6 +30,8 @@
     pull: false
     state: started
     restart_policy: always
+  notify:
+  - restart web
   tags: ['api']
 - name: Create download service container
   docker_container:
@@ -41,6 +43,8 @@
     pull: false
     state: started
     restart_policy: always
+  notify:
+  - restart web
 - name: Create task processor container
   docker_container:
     image: "{{ d4s2_docker_image }}"
@@ -61,6 +65,8 @@
       - name: "{{ d4s2_docker_network }}"
     state: started
     restart_policy: always
+  notify:
+  - restart web
   tags: ['ui']
 - name: Create reverse proxy web container
   docker_container:

--- a/d4s2_webapp/tasks/main.yml
+++ b/d4s2_webapp/tasks/main.yml
@@ -6,6 +6,8 @@
         dest="{{ d4s2_nginx.conf_dir }}/{{ d4s2_nginx.conf_file }}"
         mode=0400
         setype="svirt_sandbox_file_t"
+  notify:
+  - restart web
   tags: ['api','ui']
 - name: Create Database container
   docker_container:


### PR DESCRIPTION
- Adds a handler `restart web` that restarts the datadelivery web proxy container
- Triggers handler when services proxied by the container are changed

Verified by 

1. Running playbook without changes to versions. Web container stays running
2. Downgrade version of datadelivery-ui, run playbook. Web container restarts at end of playbook and routes traffic correctly without 503 errors.

Fixes #71 