### PR TITLE
Adds lando_k8s state to bespin_lando_k8s role

### DIFF
--- a/bespin_lando_k8s/README.md
+++ b/bespin_lando_k8s/README.md
@@ -6,7 +6,11 @@ A config file is written that is used by the pair of containers.
 This role supports deploying multiple pairs of containers to allow bespin to utilize multiple k8s clusters.
 
 ## Required fields
-- `bespin_settings` dictionary of settings used to deploy lando.k8s.* services. For each item in the `bespin_settings.k8s_clusters` dictionary a pair of runner/watcher containers and the associated config file will be created
+- `bespin_settings` dictionary of settings used to deploy lando.k8s.* services.
+- `k8s_clusters` dictionary a pair of runner/watcher containers and the associated config file will be created
+
+## Optional fields
+- `lando_k8s_state` string that is "present" or "absent" to setup or remove the specified bespin_lando_k8s instances. Defaults to "present".
 
 ## Dependencies
 None

--- a/bespin_lando_k8s/README.md
+++ b/bespin_lando_k8s/README.md
@@ -7,7 +7,7 @@ This role supports deploying multiple pairs of containers to allow bespin to uti
 
 ## Required fields
 - `bespin_settings` dictionary of settings used to deploy lando.k8s.* services.
-- `k8s_clusters` dictionary a pair of runner/watcher containers and the associated config file will be created
+- `k8s_clusters` dictionary where keys are the names of clusters to setup and the values are configuration used to setup the runner/watcher containers that will monitor the cluster
 
 ## Optional fields
 - `lando_k8s_state` string that is "present" or "absent" to setup or remove the specified bespin_lando_k8s instances. Defaults to "present".
@@ -37,13 +37,13 @@ Example role that installs a lando server and watcher with the name "hardspin":
           web:
             token: "bespin_api_token"
             url: "bespin_api_url"
-          k8s_clusters:
-            hardspin:
-              listen_queue: "hardspin_queue"
-              host: "k8shost"
-              token: "k8s_access_token"
-              namespace: "k8s_namespace_to_run_jobs_under"
-              verify_ssl: True
-              config_file_data: {} # additional config added to the end of the lando config file
+        k8s_clusters:
+          hardspin:
+            listen_queue: "hardspin_queue"
+            host: "k8shost"
+            token: "k8s_access_token"
+            namespace: "k8s_namespace_to_run_jobs_under"
+            verify_ssl: True
+            config_file_data: {} # additional config added to the end of the lando config file
 ...
 ```

--- a/bespin_lando_k8s/tasks/create-services.yml
+++ b/bespin_lando_k8s/tasks/create-services.yml
@@ -1,9 +1,9 @@
-- name: Setup lando config
+- name: "Setup lando config {{ lando_config_path }}"
   template:
     src: lando_k8s_config.yml.j2
     dest: "{{ lando_config_path }}"
 
-- name: Create lando kubernetes job runner container
+- name: "Create {{ k8s_cluster_name }} lando kubernetes job runner container"
   docker_container:
     image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
     name: "bespin-lando-k8s-{{ k8s_cluster_name }}"
@@ -14,7 +14,7 @@
     restart_policy: always
     command: python -m lando.k8s.lando "{{ lando_config_path }}"
 
-- name: Create lando kubernetes watcher container
+- name: "Create {{ k8s_cluster_name }} lando kubernetes watcher container"
   docker_container:
     image: "{{ bespin_settings.lando.build.image_name }}:{{ bespin_settings.lando.build.version }}"
     name: "bespin-watcher-k8s-{{ k8s_cluster_name }}"

--- a/bespin_lando_k8s/tasks/main.yml
+++ b/bespin_lando_k8s/tasks/main.yml
@@ -1,7 +1,17 @@
-- name: Create lando k8s services for each item in bespin_settings.k8s_clusters
+- name: Create lando k8s services for each item in k8s_clusters
+  when: lando_k8s_state|default('present') == "present"
   include_tasks: create-services.yml
   vars:
     k8s_cluster_name: "{{ item.key }}"
     lando_config_path: "/etc/lando_{{ item.key }}_config.yml"
     lando_k8s: "{{ item.value }}"
-  with_dict:  "{{ bespin_settings.k8s_clusters }}"
+  with_dict:  "{{ k8s_clusters }}"
+
+- name: Remove lando k8s services for each item in k8s_clusters
+  when: lando_k8s_state|default('present') == "absent"
+  include_tasks: remove-services.yml
+  vars:
+    k8s_cluster_name: "{{ item.key }}"
+    lando_config_path: "/etc/lando_{{ item.key }}_config.yml"
+    lando_k8s: "{{ item.value }}"
+  with_dict:  "{{ k8s_clusters }}"

--- a/bespin_lando_k8s/tasks/remove-services.yml
+++ b/bespin_lando_k8s/tasks/remove-services.yml
@@ -1,0 +1,15 @@
+
+- name: "Remove {{ k8s_cluster_name }} lando kubernetes job runner container"
+  docker_container:
+    name: "bespin-lando-k8s-{{ k8s_cluster_name }}"
+    state: absent
+
+- name: "Remove {{ k8s_cluster_name }} lando kubernetes watcher container"
+  docker_container:
+    name: "bespin-watcher-k8s-{{ k8s_cluster_name }}"
+    state: absent
+
+- name: "Remove lando config {{lando_config_path}}"
+  file:
+    path: "{{ lando_config_path }}"
+    state: absent


### PR DESCRIPTION
This will allow a user to uninstall the associated containers and config files when lando_k8s_state = 'absent'. Also moves bespin_settings.k8s_clusters out to a separate k8s_clusters variable to allow deploying without modifying bespin_settings.