### PR TITLE
Install pip packages in virtualenv, activate from /etc/profile.d

### DIFF
--- a/rnaseq/tasks/main.yml
+++ b/rnaseq/tasks/main.yml
@@ -22,6 +22,7 @@
       - mesa-libGLU
       - java-1.8.0-openjdk
       - python-pip
+      - python-virtualenv
       - python-devel
       - nfs-utils
       - libxml2-devel
@@ -61,7 +62,7 @@
   git:
     repo: 'https://github.com/alexdobin/STAR.git'
     dest: /opt/STAR
-    version: 2.5.3a
+    version: "2.5.3a"
 - name: Symlink STAR
   become: yes
   file: src=/opt/STAR/bin/Linux_x86_64/STAR dest=/usr/local/bin/STAR state=link
@@ -97,19 +98,32 @@
   pip:
     name: pip
     extra_args: --upgrade
+- name: Create virtualenv
+  become: yes
+  command: virtualenv /opt/venv creates="/opt/venv"
+- name: activate virtualenv in path
+  become: yes
+  blockinfile:
+    create: yes
+    path: /etc/profile.d/venv.sh
+    mode: 0644
+    block: source /opt/venv/bin/activate
 - name: Install cutadapt
   become: yes
   pip:
     name: cutadapt
-    version: 1.14
+    virtualenv: /opt/venv
+    version: "1.14"
 - name: Install MultiQC
   become: yes
   pip:
     name: multiqc
+    virtualenv: /opt/venv
     extra_args: "--ignore-installed"
 - name: Install HTSeq
   become: yes
   pip:
+    virtualenv: /opt/venv
     name: HTSeq
 - name: Create TrimGalore directory
   become: yes


### PR DESCRIPTION
- htseq depends on numpy, but version installed by yum as an inkscape dependency is too old
- Rather than messing with yum dependencies, decided to create a virtualenv and install there.
- quote version specifiers that should be handled as strings