### PR TITLE
Role to deploy datadrivenhypothesis.org

### DIFF
--- a/data-driven-hypothesis/README.md
+++ b/data-driven-hypothesis/README.md
@@ -1,0 +1,22 @@
+# data-driven-hypothesis
+Ansible role to deploy datadrivenhypothesis.org to an OpenShift cluster.
+
+## Requirements
+Uses the [k8s](https://docs.ansible.com/ansible/latest/modules/k8s_module.html) module so install the associated requirements.
+
+Requires `oc` command line utility to login to the OpenShift cluster. Follow 
+[instructions for installing oc](https://docs.openshift.com/enterprise/3.0/cli_reference/get_started_cli.html#installing-the-cli).
+
+## Usage
+This role requires an OpenShift cluster that a user has already authenticated with.
+A convenient method to login is to copy the login command from within the OpenShift console.
+Within the OpenShift web console click your email address in the top right corner and choose `Copy Login Command`.
+In a terminal window where you will run a playbook that uses this role paste the copied login command. 
+Then run your playbook.
+
+Example role:
+```
+...
+  roles:
+  - role: data-driven-hypothesis
+```

--- a/data-driven-hypothesis/defaults/main.yml
+++ b/data-driven-hypothesis/defaults/main.yml
@@ -1,0 +1,7 @@
+domain_name: "datadrivenhypothesis.org"
+deploy_namespace: depmap
+base_url: https://raw.githubusercontent.com/matthewhirschey/ddh/master/openshift/
+ddsclient_config_file: 'datadrivenhypothesis-ddsclient.json'
+tls_ca_certificate_file: "www_datadrivenhypothesis_org.ca-bundle"
+tls_certificate_file: "www_datadrivenhypothesis_org.crt"
+tls_key_file: "www_datadrivenhypothesis_org-privkey.pem"

--- a/data-driven-hypothesis/tasks/main.yml
+++ b/data-driven-hypothesis/tasks/main.yml
@@ -1,0 +1,71 @@
+- name: Create persistent volumes to house data
+  k8s:
+    state: present
+    definition: "{{ lookup('url', base_url + 'Storage.yaml', split_lines=False) }}"
+    namespace: "{{ deploy_namespace }}"
+
+- name: Create a Secret containing ddsclient-config-secret
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: ddsclient-config-secret
+      type: Opaque
+      data:
+        ddsclient-config: "{{ lookup('file', ddsclient_config_file, split_lines=False) | b64encode}}"
+    namespace: "{{ deploy_namespace }}"
+
+- name: Create config map for staging data script
+  k8s:
+    state: present
+    definition: "{{ lookup('url', base_url + 'DownloadDDHDataScriptConfigMap.yaml', split_lines=False) }}"
+    namespace: "{{ deploy_namespace }}"
+
+- name: Setup job staging template
+  k8s:
+    state: present
+    definition: "{{ lookup('url', base_url + 'DownloadDDHDataScriptConfigMap.yaml', split_lines=False) }}"
+    namespace: "{{ deploy_namespace }}"
+
+- name: Create Build config that builds based on ddh github master branch
+  k8s:
+    state: present
+    definition: "{{ lookup('url', base_url + 'Build.yaml', split_lines=False) }}"
+    namespace: "{{ deploy_namespace }}"
+
+- name: Create deployment for ddh-shiny-app
+  k8s:
+    state: present
+    definition: "{{ lookup('url', base_url + 'Build.yaml', split_lines=False) }}"
+    namespace: "{{ deploy_namespace }}"
+
+- name: "Create routes for {{ domain_name }} and www.{{ domain_name }}"
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Route
+      metadata:
+        labels:
+          app: ddh
+        name: "ddh-shiny-route-{{ loop_idx }}"
+      spec:
+        host: "{{ item }}"
+        path: /
+        tls:
+          caCertificate: "{{ lookup('file', tls_ca_certificate_file, split_lines=False) }}"
+          certificate: "{{ lookup('file', tls_certificate_file, split_lines=False) }}"
+          key: "{{ lookup('file', tls_key_file, split_lines=False) }}"
+          insecureEdgeTerminationPolicy: Redirect
+          termination: edge
+        to:
+          kind: Service
+          name: ddh-shiny-app
+    namespace: "{{ deploy_namespace }}"
+  loop:
+    - "{{ domain_name  }}"
+    - "www.{{ domain_name }}"
+  loop_control:
+    index_var: loop_idx


### PR DESCRIPTION
Adds a role that can be used to deploy DDH based on the master branch of [matthewhirschey/ddh](https://github.com/matthewhirschey/ddh). This role is based on the [ddh openshift README](https://github.com/matthewhirschey/ddh/blob/master/openshift/README.md).
