### PR TITLE
add options to limit imads portal log size

### DIFF
--- a/imads_webapp/defaults/main.yml
+++ b/imads_webapp/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+portal_log_driver: json-file
+portal_log_max_size: 10m
+portal_log_max_file: 5

--- a/imads_webapp/tasks/setup_portal.yml
+++ b/imads_webapp/tasks/setup_portal.yml
@@ -13,6 +13,10 @@
     ports:
       - "80:80"
       - "443:443"
+    log_driver: "{{ portal_log_driver }}"
+    log_options:
+      max-size: "{{ portal_log_max_size }}"
+      max-file: "{{ portal_log_max_file }}"
     pull: false
     state: started
     restart_policy: always


### PR DESCRIPTION
Configures imads docker container to use log rotation. Otherwise when the log fills up and the pod is restarted apache fails to start due to being out of space.