### PR TITLE
fix build_docker_image issue #86

### DIFF
--- a/build_docker_image/tasks/main.yml
+++ b/build_docker_image/tasks/main.yml
@@ -1,6 +1,11 @@
-- name: Ensure directory exists for cloning git repo
+- name: Ensure the base directory exists
   file:
     state: directory
+    path: "{{ local_repo_root }}"
+
+- name: Delete any existing repo directory
+  file:
+    state: absent
     path: "{{ local_repo_root }}/{{ image_name }}-{{ version }}"
 
 # Note that this checks out the git repo to a specific local directory based on the


### PR DESCRIPTION
Changes build_docker_image role to assure destination directory is absent before running git clone.
Also assures base directory exists.
Fixes #86